### PR TITLE
NCloud SDK - VPC 마이그레이션

### DIFF
--- a/packages/ncloud-sdk/src/services/vpc/VpcApi.ts
+++ b/packages/ncloud-sdk/src/services/vpc/VpcApi.ts
@@ -1,22 +1,114 @@
 import { VpcApiClient } from './VpcApiClient';
 import { ApiKeyCredentials } from './types';
-
+import { CreateVpcRequest } from './models/CreateVpcRequest';
+import { CreateVpcResponse } from './models/CreateVpcResponse';
+import { DeleteVpcRequest } from './models/DeleteVpcRequest';
+import { DeleteVpcResponse } from './models/DeleteVpcResponse';
+import { GetVpcListRequest } from './models/GetVpcListRequest';
+import { GetVpcListResponse } from './models/GetVpcListResponse';
+import { GetVpcDetailRequest } from './models/GetVpcDetailRequest';
+import { GetVpcDetailResponse } from './models/GetVpcDetailResponse';
+/**
+ * 네이버 클라우드 플랫폼의 VPC(Virtual Private Cloud) API를 처리하는 클래스
+ * @class VpcApi
+ */
 export class VpcApi {
     private client: VpcApiClient;
     private readonly resourcePath: string;
+
+    /**
+     * VpcApi 클래스의 새 인스턴스를 생성합니다.
+     * @param {ApiKeyCredentials} [apiKey] - 네이버 클라우드 플랫폼 API 인증 정보
+     * @example
+     * const vpcApi = new VpcApi({
+     *   accessKey: 'access-key',
+     *   secretKey: 'secret-key'
+     * });
+     */
     constructor(apiKey?: ApiKeyCredentials) {
         this.resourcePath = '/vpc/v2';
         this.client = new VpcApiClient(apiKey);
     }
 
-    async createVpc(params: {
-        regionCode: string;
-        vpcName: string;
-        ipv4CidrBlock: string;
-    }) {
+    /**
+     * 새로운 VPC를 생성합니다.
+     * @param {CreateVpcRequest} params - VPC 생성 요청 파라미터
+     * @returns {Promise<CreateVpcResponse>} VPC 생성 결과
+     *
+     * @example
+     * const response = await vpcApi.createVpc({
+     *   regionCode: 'KR',
+     *   vpcName: 'boost-vpc',
+     *   ipv4CidrBlock: '10.0.0.0/16'
+     * });
+     *
+     */
+    async createVpc(params: CreateVpcRequest): Promise<CreateVpcResponse> {
         return await this.client.request({
             method: 'POST',
-            url: this.resourcePath + '/createVpc',
+            url: `${this.resourcePath}/createVpc`,
+            params,
+        });
+    }
+
+    /**
+     * VPC를 삭제합니다.
+     * @param {DeleteVpcRequest} params - VPC 삭제 요청 파라미터
+     * @returns {Promise<DeleteVpcResponse>} VPC 삭제 결과
+     *
+     * @example
+     * const response = await vpcApi.deleteVpc({
+     *   regionCode: 'KR',
+     *   vpcNo: 'vpc-123'
+     * });
+     *
+     */
+    async deleteVpc(params: DeleteVpcRequest): Promise<DeleteVpcResponse> {
+        return await this.client.request({
+            method: 'POST',
+            url: `${this.resourcePath}/deleteVpc`,
+            params,
+        });
+    }
+
+    /**
+     * VPC 목록을 조회합니다.
+     * @param {GetVpcListRequest} params - VPC 목록 조회 요청 파라미터
+     * @returns {Promise<GetVpcListResponse>} VPC 목록 조회 결과
+     *
+     * @example
+     * const response = await vpcApi.getVpcList({
+     *   regionCode: 'KR',
+     *   vpcStatusCode: 'RUN'
+     * });
+     *
+     */
+    async getVpcList(params: GetVpcListRequest): Promise<GetVpcListResponse> {
+        return await this.client.request({
+            method: 'GET',
+            url: `${this.resourcePath}/getVpcList`,
+            params,
+        });
+    }
+
+    /**
+     * 특정 VPC의 상세 정보를 조회합니다.
+     * @param {GetVpcDetailRequest} params - VPC 상세 정보 조회 요청 파라미터
+     * @returns {Promise<GetVpcDetailResponse>} VPC 상세 정보 조회 결과
+     *
+     * @example
+     * const response = await vpcApi.getVpcDetail({
+     *   regionCode: 'KR',
+     *   vpcNo: 'vpc-123'
+     * });
+     *
+     */
+    async getVpcDetail(
+        params: GetVpcDetailRequest
+    ): Promise<GetVpcDetailResponse> {
+        return await this.client.request({
+            method: 'GET',
+            url: `${this.resourcePath}/getVpcDetail`,
             params,
         });
     }

--- a/packages/ncloud-sdk/src/services/vpc/models/CommonCode.ts
+++ b/packages/ncloud-sdk/src/services/vpc/models/CommonCode.ts
@@ -1,6 +1,8 @@
 /**
- * CommonCode 객체
- * @see {@link https://api.ncloud-docs.com/docs/common-vapidatatype-commoncode}
+ * VPC 상태를 나타내는 공통 코드
+ * @typedef {Object} CommonCode
+ * @property {string} code - 5자리 이내의 코드 (INIT | CREAT | RUN | NSTOP)
+ * @property {string} codeName - 코드에 해당하는 코드 이름 (INIT 상태 | 생성 | 운영 | 정상 정지)
  */
 export interface CommonCode {
     code: string;

--- a/packages/ncloud-sdk/src/services/vpc/models/CommonCode.ts
+++ b/packages/ncloud-sdk/src/services/vpc/models/CommonCode.ts
@@ -1,0 +1,8 @@
+/**
+ * CommonCode 객체
+ * @see {@link https://api.ncloud-docs.com/docs/common-vapidatatype-commoncode}
+ */
+export interface CommonCode {
+    code: string;
+    codeName: string;
+}

--- a/packages/ncloud-sdk/src/services/vpc/models/CommonResponse.ts
+++ b/packages/ncloud-sdk/src/services/vpc/models/CommonResponse.ts
@@ -1,4 +1,12 @@
 import { VpcList } from './VpcList';
+/**
+ * API 응답의 기본 구조
+ * @typedef {Object} CommonResponse
+ * @property {string} requestId - 요청 ID
+ * @property {string} returnCode - 응답 코드
+ * @property {string} returnMessage - 응답 메시지
+ * @property {number} totalRows - 전체 행 수
+ */
 export interface CommonResponse extends VpcList {
     requestId: string;
     returnCode: string;

--- a/packages/ncloud-sdk/src/services/vpc/models/CommonResponse.ts
+++ b/packages/ncloud-sdk/src/services/vpc/models/CommonResponse.ts
@@ -1,0 +1,7 @@
+import { VpcList } from './VpcList';
+export interface CommonResponse extends VpcList {
+    requestId: string;
+    returnCode: string;
+    returnMessage: string;
+    totalRows: number;
+}

--- a/packages/ncloud-sdk/src/services/vpc/models/CreateVpcRequest.ts
+++ b/packages/ncloud-sdk/src/services/vpc/models/CreateVpcRequest.ts
@@ -1,0 +1,18 @@
+export interface CreateVpcRequest {
+    /**
+     * VPC 이름
+     */
+    regionCode: string;
+    /**
+     * VPC 이름
+     */
+    vpcName: string;
+    /**
+     * VPC CIDR 블록
+     */
+    ipv4CidrBlock: string;
+    /**
+     * 응답 결과의 형식
+     */
+    responseFormatType?: string;
+}

--- a/packages/ncloud-sdk/src/services/vpc/models/CreateVpcRequest.ts
+++ b/packages/ncloud-sdk/src/services/vpc/models/CreateVpcRequest.ts
@@ -1,18 +1,13 @@
+/**
+ * VPC 생성 요청 파라미터
+ * @typedef {Object} CreateVpcRequest
+ * @property {string} [regionCode] - VPC를 생성할 리전 코드 (Optional)
+ * @property {string} [vpcName] - VPC 이름 (Optional, 3~30자 영문 소문자/숫자/'-')
+ * @property {string} ipv4CidrBlock - VPC의 사설 IPv4 주소 범위 (Required)
+ */
 export interface CreateVpcRequest {
-    /**
-     * VPC 이름
-     */
     regionCode: string;
-    /**
-     * VPC 이름
-     */
     vpcName: string;
-    /**
-     * VPC CIDR 블록
-     */
     ipv4CidrBlock: string;
-    /**
-     * 응답 결과의 형식
-     */
     responseFormatType?: string;
 }

--- a/packages/ncloud-sdk/src/services/vpc/models/CreateVpcResponse.ts
+++ b/packages/ncloud-sdk/src/services/vpc/models/CreateVpcResponse.ts
@@ -1,0 +1,2 @@
+import { CommonResponse } from './CommonResponse';
+export interface CreateVpcResponse extends CommonResponse {}

--- a/packages/ncloud-sdk/src/services/vpc/models/CreateVpcResponse.ts
+++ b/packages/ncloud-sdk/src/services/vpc/models/CreateVpcResponse.ts
@@ -1,2 +1,30 @@
 import { CommonResponse } from './CommonResponse';
+
+/**
+ * VPC 생성 API 응답
+ * @interface CreateVpcResponse
+ * @extends {CommonResponse}
+ * @see {@link https://api.ncloud-docs.com/docs/networking-vpc-vpcmanagement-createvpc}
+ *
+ * @example
+ * {
+ *   "requestId": "21a29c59-3139-4c23-9f92-10c1fddafef6",
+ *   "returnCode": "0",
+ *   "returnMessage": "success",
+ *   "totalRows": 1,
+ *   "vpcList": [
+ *     {
+ *       "vpcNo": "1234",
+ *       "vpcName": "test-vpc",
+ *       "ipv4CidrBlock": "10.0.0.0/16",
+ *       "vpcStatus": {
+ *         "code": "INIT",
+ *         "codeName": "init"
+ *       },
+ *       "regionCode": "KR",
+ *       "createDate": "2020-07-27T17:17:05+0900"
+ *     }
+ *   ]
+ * }
+ */
 export interface CreateVpcResponse extends CommonResponse {}

--- a/packages/ncloud-sdk/src/services/vpc/models/DeleteVpcRequest.ts
+++ b/packages/ncloud-sdk/src/services/vpc/models/DeleteVpcRequest.ts
@@ -1,0 +1,14 @@
+export interface DeleteVpcRequest {
+    /**
+     * VPC 리전 코드
+     */
+    regionCode: string;
+    /**
+     * VPC 번호
+     */
+    vpcNo: string;
+    /**
+     * 응답 결과의 형식
+     */
+    responseFormatType: string;
+}

--- a/packages/ncloud-sdk/src/services/vpc/models/DeleteVpcRequest.ts
+++ b/packages/ncloud-sdk/src/services/vpc/models/DeleteVpcRequest.ts
@@ -1,14 +1,11 @@
+/**
+ * VPC 삭제 요청 파라미터
+ * @typedef {Object} DeleteVpcRequest
+ * @property {string} [regionCode] - 삭제할 VPC의 리전 코드 (Optional)
+ * @property {string} vpcNo - 삭제할 VPC 번호 (Required)
+ */
 export interface DeleteVpcRequest {
-    /**
-     * VPC 리전 코드
-     */
     regionCode: string;
-    /**
-     * VPC 번호
-     */
     vpcNo: string;
-    /**
-     * 응답 결과의 형식
-     */
     responseFormatType: string;
 }

--- a/packages/ncloud-sdk/src/services/vpc/models/DeleteVpcResponse.ts
+++ b/packages/ncloud-sdk/src/services/vpc/models/DeleteVpcResponse.ts
@@ -1,2 +1,30 @@
 import { CommonResponse } from './CommonResponse';
+
+/**
+ * VPC 삭제 API 응답
+ * @interface DeleteVpcResponse
+ * @extends {CommonResponse}
+ * @see {@link https://api.ncloud-docs.com/docs/networking-vpc-vpcmanagement-deletevpc}
+ *
+ * @example
+ * {
+ *   "requestId": "f6d32d67-ab92-4096-b240-ed2e96d8d265",
+ *   "returnCode": "0",
+ *   "returnMessage": "success",
+ *   "totalRows": 1,
+ *   "vpcList": [
+ *     {
+ *       "vpcNo": "1234",
+ *       "vpcName": "test-vpc",
+ *       "ipv4CidrBlock": "10.0.0.0/16",
+ *       "vpcStatus": {
+ *         "code": "TERMTING",
+ *         "codeName": "terminating"
+ *       },
+ *       "regionCode": "KR",
+ *       "createDate": "2020-07-27T17:17:05+0900"
+ *     }
+ *   ]
+ * }
+ */
 export interface DeleteVpcResponse extends CommonResponse {}

--- a/packages/ncloud-sdk/src/services/vpc/models/DeleteVpcResponse.ts
+++ b/packages/ncloud-sdk/src/services/vpc/models/DeleteVpcResponse.ts
@@ -1,0 +1,2 @@
+import { CommonResponse } from './CommonResponse';
+export interface DeleteVpcResponse extends CommonResponse {}

--- a/packages/ncloud-sdk/src/services/vpc/models/GetVpcDetailRequest.ts
+++ b/packages/ncloud-sdk/src/services/vpc/models/GetVpcDetailRequest.ts
@@ -1,14 +1,11 @@
+/**
+ * VPC 상세 정보 조회 요청 파라미터
+ * @typedef {Object} GetVpcDetailRequest
+ * @property {string} [regionCode] - 조회할 리전 코드 (Optional)
+ * @property {string} vpcNo - 조회할 VPC 번호 (Required)
+ */
 export interface GetVpcDetailRequest {
-    /**
-     * VPC 리전 코드
-     */
     regionCode: string;
-    /**
-     * Vpc 번호
-     */
     vpcNo: string;
-    /**
-     * 응답 결과의 형식
-     */
     responseFormatType?: string;
 }

--- a/packages/ncloud-sdk/src/services/vpc/models/GetVpcDetailRequest.ts
+++ b/packages/ncloud-sdk/src/services/vpc/models/GetVpcDetailRequest.ts
@@ -1,0 +1,14 @@
+export interface GetVpcDetailRequest {
+    /**
+     * VPC 리전 코드
+     */
+    regionCode: string;
+    /**
+     * Vpc 번호
+     */
+    vpcNo: string;
+    /**
+     * 응답 결과의 형식
+     */
+    responseFormatType?: string;
+}

--- a/packages/ncloud-sdk/src/services/vpc/models/GetVpcDetailResponse.ts
+++ b/packages/ncloud-sdk/src/services/vpc/models/GetVpcDetailResponse.ts
@@ -1,2 +1,30 @@
 import { CommonResponse } from './CommonResponse';
+
+/**
+ * VPC 상세 정보 조회 API 응답
+ * @interface GetVpcDetailResponse
+ * @extends {CommonResponse}
+ * @see {@link https://api.ncloud-docs.com/docs/networking-vpc-vpcmanagement-getvpcdetail}
+ *
+ * @example
+ * {
+ *   "requestId": "13f37a8e-780f-4f32-9115-503a2026cf6d",
+ *   "returnCode": "0",
+ *   "returnMessage": "success",
+ *   "totalRows": 1,
+ *   "vpcList": [
+ *     {
+ *       "vpcNo": "1234",
+ *       "vpcName": "test-vpc",
+ *       "ipv4CidrBlock": "10.0.0.0/16",
+ *       "vpcStatus": {
+ *         "code": "RUN",
+ *         "codeName": "run"
+ *       },
+ *       "regionCode": "KR",
+ *       "createDate": "2020-07-16T22:23:50+0900"
+ *     }
+ *   ]
+ * }
+ */
 export interface GetVpcDetailResponse extends CommonResponse {}

--- a/packages/ncloud-sdk/src/services/vpc/models/GetVpcDetailResponse.ts
+++ b/packages/ncloud-sdk/src/services/vpc/models/GetVpcDetailResponse.ts
@@ -1,0 +1,2 @@
+import { CommonResponse } from './CommonResponse';
+export interface GetVpcDetailResponse extends CommonResponse {}

--- a/packages/ncloud-sdk/src/services/vpc/models/GetVpcListRequest.ts
+++ b/packages/ncloud-sdk/src/services/vpc/models/GetVpcListRequest.ts
@@ -1,0 +1,22 @@
+export interface GetVpcListRequest {
+    /**
+     * VPC 리전 코드
+     */
+    regionCode: string;
+    /**
+     * VPC 상태 코드
+     */
+    vpcStatusCode?: string;
+    /**
+     * VPC 이름
+     */
+    vpcName?: string;
+    /**
+     * VPC 번호
+     */
+    vpcNoList?: string[];
+    /**
+     * 응답 결과의 형식
+     */
+    responseFormatType?: string;
+}

--- a/packages/ncloud-sdk/src/services/vpc/models/GetVpcListRequest.ts
+++ b/packages/ncloud-sdk/src/services/vpc/models/GetVpcListRequest.ts
@@ -1,22 +1,15 @@
+/**
+ * VPC 목록 조회 요청 파라미터
+ * @typedef {Object} GetVpcListRequest
+ * @property {string} [regionCode] - 조회할 리전 코드 (Optional)
+ * @property {string} [vpcStatusCode] - VPC 상태 코드 (Optional, INIT|CREATING|RUN|TERMTING)
+ * @property {string} [vpcName] - VPC 이름으로 검색 (Optional)
+ * @property {string[]} [vpcNoList] - VPC 번호 목록으로 검색 (Optional)
+ */
 export interface GetVpcListRequest {
-    /**
-     * VPC 리전 코드
-     */
     regionCode: string;
-    /**
-     * VPC 상태 코드
-     */
     vpcStatusCode?: string;
-    /**
-     * VPC 이름
-     */
     vpcName?: string;
-    /**
-     * VPC 번호
-     */
     vpcNoList?: string[];
-    /**
-     * 응답 결과의 형식
-     */
     responseFormatType?: string;
 }

--- a/packages/ncloud-sdk/src/services/vpc/models/GetVpcListResponse.ts
+++ b/packages/ncloud-sdk/src/services/vpc/models/GetVpcListResponse.ts
@@ -1,0 +1,2 @@
+import { CommonResponse } from './CommonResponse';
+export interface GetVpcListResponse extends CommonResponse {}

--- a/packages/ncloud-sdk/src/services/vpc/models/GetVpcListResponse.ts
+++ b/packages/ncloud-sdk/src/services/vpc/models/GetVpcListResponse.ts
@@ -1,2 +1,30 @@
 import { CommonResponse } from './CommonResponse';
+
+/**
+ * VPC 목록 조회 API 응답
+ * @interface GetVpcListResponse
+ * @extends {CommonResponse}
+ * @see {@link https://api.ncloud-docs.com/docs/networking-vpc-vpcmanagement-getvpclist}
+ *
+ * @example
+ * {
+ *   "requestId": "9b37ea3e-3ca9-462f-abad-6e23a35fcb76",
+ *   "returnCode": "0",
+ *   "returnMessage": "success",
+ *   "totalRows": 1,
+ *   "vpcList": [
+ *     {
+ *       "vpcNo": "1234",
+ *       "vpcName": "test-vpc",
+ *       "ipv4CidrBlock": "10.0.0.0/16",
+ *       "vpcStatus": {
+ *         "code": "RUN",
+ *         "codeName": "run"
+ *       },
+ *       "regionCode": "KR",
+ *       "createDate": "2020-07-16T22:23:50+0900"
+ *     }
+ *   ]
+ * }
+ */
 export interface GetVpcListResponse extends CommonResponse {}

--- a/packages/ncloud-sdk/src/services/vpc/models/Vpc.ts
+++ b/packages/ncloud-sdk/src/services/vpc/models/Vpc.ts
@@ -1,4 +1,14 @@
 import { CommonCode } from './CommonCode';
+/**
+ * VPC 정보를 나타내는 인터페이스
+ * @typedef {Object} Vpc
+ * @property {string} vpcNo - VPC 번호
+ * @property {string} vpcName - VPC 이름 (3~30자, 영문 소문자/숫자/'-' 허용)
+ * @property {string} ipv4CidrBlock - VPC의 사설 IPv4 주소 범위
+ * @property {CommonCode} vpcStatus - VPC 상태 정보
+ * @property {string} regionCode - VPC가 위치한 리전 코드
+ * @property {string} createDate - 생성 일시
+ */
 export interface Vpc {
     vpcNo: string;
     vpcName: string;

--- a/packages/ncloud-sdk/src/services/vpc/models/Vpc.ts
+++ b/packages/ncloud-sdk/src/services/vpc/models/Vpc.ts
@@ -1,0 +1,9 @@
+import { CommonCode } from './CommonCode';
+export interface Vpc {
+    vpcNo: string;
+    vpcName: string;
+    ivp4CidrBlock: string;
+    vpcStatus: CommonCode;
+    regionCode: string;
+    createDate: Date;
+}

--- a/packages/ncloud-sdk/src/services/vpc/models/VpcList.ts
+++ b/packages/ncloud-sdk/src/services/vpc/models/VpcList.ts
@@ -1,4 +1,29 @@
 import { Vpc } from './Vpc';
+
+/**
+ * VPC 목록 정보
+ * @interface VpcList
+ * @property {number} totalRows - 전체 VPC 개수
+ * @property {Vpc[]} vpcList - VPC 목록
+ *
+ * @example
+ * {
+ *   "totalRows": 1,
+ *   "vpcList": [
+ *     {
+ *       "vpcNo": "1234",
+ *       "vpcName": "test-vpc",
+ *       "ipv4CidrBlock": "10.0.0.0/16",
+ *       "vpcStatus": {
+ *         "code": "RUN",
+ *         "codeName": "run"
+ *       },
+ *       "regionCode": "KR",
+ *       "createDate": "2020-07-16T22:23:50+0900"
+ *     }
+ *   ]
+ * }
+ */
 export interface VpcList {
     totalRows: number;
     vpcList: Vpc[];

--- a/packages/ncloud-sdk/src/services/vpc/models/VpcList.ts
+++ b/packages/ncloud-sdk/src/services/vpc/models/VpcList.ts
@@ -1,0 +1,5 @@
+import { Vpc } from './Vpc';
+export interface VpcList {
+    totalRows: number;
+    vpcList: Vpc[];
+}


### PR DESCRIPTION
## 주요 변경 사항

- 기존 [NClous-sdk-js(vpc)](https://github.com/NaverCloudPlatform/ncloud-sdk-js/tree/master/lib/services/vpc) 코드 버전이 ES5 콜백함수가 너무 복잡하고, 프로토타입을 클래스 형식으로 마이그레이션 하였음.

- 프로토타입
```ts
function ApiClient(apiKey) {
    this.basePath = apigwEndpoint + '/vserver/v2';
    this.apiKey = apiKey;
    this.authentications = {
        'x-ncp-iam': {type: 'apiKey', 'in': 'header', name: 'x-ncp-iam'},
    };
}

ApiClient.prototype.paramToString = function(param) {
    if (param == undefined || param == null) {
        return '';
    }
    return param.toString();
};
```

- ES6 클래스
```ts
export class VpcApiClient {
    private readonly baseURL: string;
    private readonly apiKey?: ApiKeyCredentials;
    private readonly axiosInstance: AxiosInstance;

    constructor(apiKey?: ApiKeyCredentials) {
        this.baseURL = process.env.NCLOUD_API_GW || 'https://ncloud.apigw.ntruss.com';
        this.apiKey = apiKey;
        this.axiosInstance = axios.create({
            baseURL: this.baseURL,
            timeout: 60000,
            headers: {
                'Content-Type': 'application/x-www-form-urlencoded',
            },
        });
        this.setupRequestInterceptor();
    }

    private paramToString(param: any): string {
        if (param == null) {
            return '';
        }
        return String(param);
    }
}
```

- 기존 콜백 함수
```ts
exports.prototype.callApi = function(path, httpMethod, pathParams,
    queryParams, headerParams, formParams, bodyParam, callback) {
    var url = this.buildUrl(path, pathParams);
    var request = superagent(httpMethod, url);
    
    if (this.timeout) {
        request.timeout(this.timeout);
    }
    
    request.query(queryParams);
    request.set(headerParams);
    
    if (formParams) {
        request.send(formParams);
    }
    
    var _this = this;
    request.end(function(error, response) {
        if (callback) {
            var data = null;
            if (!error) {
                try {
                    data = _this.deserialize(response, returnType);
                } catch (err) {
                    error = err;
                }
            }
            callback(error, data, response);
        }
    });
};
```

- promise, async/await
```ts
async request(config: AxiosRequestConfig): Promise<any> {
    try {
        const response = await this.axiosInstance.request({
            ...config,
            params: {
                ...config.params,
                responseFormatType: 'json',
            },
        });
        return response.data;
    } catch (error) {
        if (axios.isAxiosError(error)) {
            console.error('API Error:', {
                status: error.response?.status,
                data: error.response?.data,
            });
            throw new Error(error.response?.data?.message || error.message);
        }
        throw error;
    }
}
```

## 이점
### 콜백 지옥
- 기존 ES5 버전의 SDK에서는 콜백함수로 비동기를 처리해서 콜백이 여러번 중첩되게 되는 콜백 지옥이 많이 보여서, 코드를 알아보기 힘들었습니다.
- 마이그레이션한 SDK에서는 promise와 async/await 으로 비동기를 처리하여 코드가 더 간결해지고, 가독성이 좋아졌습니다.