### PR TITLE
[Client#1] - Pan Zoom 구현

### DIFF
--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -1,3 +1,4 @@
+import CanvasFlow from '@components/CanvasFlow';
 import Header from '@components/Header';
 import Sidebar from '@components/Sidebar';
 import Box from '@mui/material/Box';
@@ -16,9 +17,11 @@ function App() {
                     width: '100%',
                     display: 'flex',
                     flexDirection: 'column',
+                    overflow: 'hidden',
                 }}
             >
                 <Header />
+                <CanvasFlow></CanvasFlow>
             </Box>
         </Box>
     );

--- a/packages/client/src/components/Background/LinePattern.tsx
+++ b/packages/client/src/components/Background/LinePattern.tsx
@@ -1,0 +1,22 @@
+export default ({ points }: { points: string }) => {
+    return (
+        <g>
+            <pattern
+                id="gridPatternMajor"
+                x="0"
+                y="0"
+                width="90"
+                height="90"
+                patternUnits="userSpaceOnUse"
+            >
+                <path
+                    d="M 0 0 L 90 0 90 90 0 90 z"
+                    stroke="#54626f"
+                    strokeWidth="1"
+                    fill="none"
+                ></path>
+            </pattern>
+            <polygon points={points} fill="url(#gridPatternMajor)"></polygon>
+        </g>
+    );
+};

--- a/packages/client/src/components/Background/SubLinePattern.tsx
+++ b/packages/client/src/components/Background/SubLinePattern.tsx
@@ -1,0 +1,22 @@
+export default ({ points }: { points: string }) => {
+    return (
+        <g>
+            <pattern
+                id="gridPatternMinor"
+                x="0"
+                y="0"
+                width="90"
+                height="90"
+                patternUnits="userSpaceOnUse"
+            >
+                <path d="M 0 45 L 90 45" stroke="#eee" strokeWidth="1"></path>
+                <path
+                    d="M 45 0 L 45 90"
+                    stroke="#eeeeee"
+                    strokeWidth="1"
+                ></path>
+            </pattern>
+            <polygon points={points} fill="url(#gridPatternMinor)"></polygon>
+        </g>
+    );
+};

--- a/packages/client/src/components/Background/index.tsx
+++ b/packages/client/src/components/Background/index.tsx
@@ -1,0 +1,17 @@
+import LinePattern from '@components/Background/LinePattern';
+import SubLinePattern from '@components/Background/SubLinePattern';
+
+export default ({
+    points,
+    showSubLines,
+}: {
+    points: string;
+    showSubLines: boolean;
+}) => {
+    return (
+        <>
+            {showSubLines && <SubLinePattern points={points} />}
+            <LinePattern points={points} />
+        </>
+    );
+};

--- a/packages/client/src/components/CanvasFlow/index.tsx
+++ b/packages/client/src/components/CanvasFlow/index.tsx
@@ -1,0 +1,51 @@
+import Background from '@components/Background';
+import usePanZoom from '@hooks/usePanZoom';
+import { PropsWithChildren, useRef } from 'react';
+
+export default ({ children }: PropsWithChildren) => {
+    const ref = useRef<HTMLDivElement>(null);
+    const {
+        viewBox,
+        isDragging,
+        handleMoveStart,
+        handleMove,
+        handleMoveEnd,
+        handleZoom,
+    } = usePanZoom(ref);
+
+    const backgroundPoints = [
+        [viewBox.x, viewBox.y],
+        [viewBox.x + viewBox.width, viewBox.y],
+        [viewBox.x + viewBox.width, viewBox.y + viewBox.height],
+        [viewBox.x, viewBox.y + viewBox.height],
+    ];
+
+    return (
+        <div
+            ref={ref}
+            style={{
+                width: '100%',
+                height: '100%',
+                cursor: isDragging ? 'grab' : 'auto',
+            }}
+            onWheel={handleZoom}
+            onMouseDown={handleMoveStart}
+            onMouseMove={handleMove}
+            onMouseUp={handleMoveEnd}
+        >
+            <svg
+                width="100%"
+                height="100%"
+                viewBox={`${viewBox.x} ${viewBox.y} ${viewBox.width} ${viewBox.height}`}
+            >
+                <Background
+                    points={backgroundPoints
+                        .map((point) => point.join(','))
+                        .join(' ')}
+                    showSubLines={true}
+                />
+                {children}
+            </svg>
+        </div>
+    );
+};

--- a/packages/client/src/hooks/usePanZoom.ts
+++ b/packages/client/src/hooks/usePanZoom.ts
@@ -1,0 +1,111 @@
+import {
+    MouseEvent,
+    WheelEvent,
+    RefObject,
+    useLayoutEffect,
+    useRef,
+    useState,
+} from 'react';
+
+export default (ref: RefObject<HTMLElement>) => {
+    const [viewBox, setViewBox] = useState({
+        x: 0,
+        y: 0,
+        width: 0,
+        height: 0,
+    });
+
+    const [isDragging, setIsDragging] = useState(false);
+    const [dragStart, setDragStart] = useState({ x: 0, y: 0 });
+    const dragStartMousePosition = useRef({ x: 0, y: 0 });
+    const dragStartViewBoxPosition = useRef({ x: 0, y: 0 });
+
+    const handleZoom = (e: WheelEvent) => {
+        const { deltaY, clientX, clientY } = e;
+
+        // scroll up -> scale down, scroll up -> scale down
+        const scaleFactor = 0.1;
+        const ratio = deltaY > 0 ? 1 + scaleFactor : 1 - scaleFactor;
+
+        const zoomPan = e.currentTarget.getBoundingClientRect();
+
+        const relativeX = clientX - zoomPan.left;
+        const relativeY = clientY - zoomPan.top;
+        const mouseX = (relativeX / zoomPan.width) * viewBox.width + viewBox.x;
+        const mouseY =
+            (relativeY / zoomPan.height) * viewBox.height + viewBox.y;
+        const newX = mouseX - (mouseX - viewBox.x) * ratio;
+        const newY = mouseY - (mouseY - viewBox.y) * ratio;
+
+        const newWidth = viewBox.width * ratio;
+        const newHeight = viewBox.height * ratio;
+
+        setViewBox({
+            x: newX,
+            y: newY,
+            width: newWidth,
+            height: newHeight,
+        });
+    };
+
+    const handleMoveStart = (e: MouseEvent) => {
+        setIsDragging(true);
+
+        const { clientX, clientY } = e;
+        dragStartMousePosition.current = { x: clientX, y: clientY };
+        dragStartViewBoxPosition.current = { x: viewBox.x, y: viewBox.y };
+    };
+
+    const handleMove = (e: MouseEvent) => {
+        if (!isDragging || !ref.current) return;
+
+        const zoomPan = ref.current.getBoundingClientRect();
+        const viewBoxWidthPerPixel = viewBox.width / zoomPan.width;
+        const viewBoxHeightPerPixel = viewBox.height / zoomPan.height;
+
+        const { x: mouseStartX, y: mouseStartY } =
+            dragStartMousePosition.current;
+
+        const distanceX = e.clientX - mouseStartX;
+        const distanceY = e.clientY - mouseStartY;
+        const dx = distanceX * viewBoxWidthPerPixel;
+        const dy = distanceY * viewBoxHeightPerPixel;
+
+        const { x: viewBoxStartX, y: viewBoxStartY } =
+            dragStartViewBoxPosition.current;
+
+        setViewBox((prev) => ({
+            ...prev,
+            x: viewBoxStartX - dx,
+            y: viewBoxStartY - dy,
+        }));
+    };
+
+    const handleMoveEnd = () => setIsDragging(false);
+
+    useLayoutEffect(() => {
+        const handleResize = () => {
+            if (ref.current) {
+                setViewBox({
+                    x: 0,
+                    y: 0,
+                    width: ref.current.offsetWidth,
+                    height: ref.current.offsetHeight,
+                });
+            }
+        };
+
+        handleResize();
+        window.addEventListener('resize', handleResize);
+        return () => window.removeEventListener('resize', handleResize);
+    }, []);
+
+    return {
+        viewBox,
+        isDragging,
+        handleMoveStart,
+        handleMoveEnd,
+        handleMove,
+        handleZoom,
+    };
+};

--- a/packages/client/src/hooks/useZoomPan.ts
+++ b/packages/client/src/hooks/useZoomPan.ts
@@ -16,7 +16,7 @@ export default (ref: RefObject<HTMLElement>) => {
         height: 0,
     });
 
-    const [isPanZoomDragging, setIsPanZoomDragging] = useState(false);
+    const [isDragging, setIsDragging] = useState(false);
     const dragStartMousePosition = useRef({ x: 0, y: 0 });
     const dragStartViewBoxPosition = useRef({ x: 0, y: 0 });
 
@@ -49,7 +49,7 @@ export default (ref: RefObject<HTMLElement>) => {
     };
 
     const handleMoveStart = (e: ReactMouseEvent) => {
-        setIsPanZoomDragging(true);
+        setIsDragging(true);
 
         const { clientX, clientY } = e;
         dragStartMousePosition.current = { x: clientX, y: clientY };
@@ -57,7 +57,7 @@ export default (ref: RefObject<HTMLElement>) => {
     };
 
     const handleMove = (e: MouseEvent) => {
-        if (!isPanZoomDragging || !ref.current) return;
+        if (!isDragging || !ref.current) return;
 
         const zoomPan = ref.current.getBoundingClientRect();
         const viewBoxWidthPerPixel = viewBox.width / zoomPan.width;
@@ -81,7 +81,7 @@ export default (ref: RefObject<HTMLElement>) => {
         }));
     };
 
-    const handleMoveEnd = () => setIsPanZoomDragging(false);
+    const handleMoveEnd = () => setIsDragging(false);
 
     useLayoutEffect(() => {
         const handleResize = () => {
@@ -101,7 +101,7 @@ export default (ref: RefObject<HTMLElement>) => {
     }, []);
 
     useEffect(() => {
-        if (isPanZoomDragging) {
+        if (isDragging) {
             window.addEventListener('mousemove', handleMove);
             window.addEventListener('mouseup', handleMoveEnd);
         } else {
@@ -113,11 +113,11 @@ export default (ref: RefObject<HTMLElement>) => {
             window.removeEventListener('mousemove', handleMove);
             window.removeEventListener('mouseup', handleMoveEnd);
         };
-    }, [isPanZoomDragging, handleMove, handleMoveEnd]);
+    }, [isDragging, handleMove, handleMoveEnd]);
 
     return {
         viewBox,
-        isPanZoomDragging,
+        isDragging,
         handleMoveStart,
         handleMoveEnd,
         handleMove,

--- a/packages/client/src/main.tsx
+++ b/packages/client/src/main.tsx
@@ -2,7 +2,7 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App.tsx';
 import { ThemeProvider, CssBaseline } from '@mui/material';
-import theme from './theme/index.ts';
+import theme from '@theme';
 
 createRoot(document.getElementById('root')!).render(
     <StrictMode>

--- a/packages/client/src/main.tsx
+++ b/packages/client/src/main.tsx
@@ -10,5 +10,5 @@ createRoot(document.getElementById('root')!).render(
             <CssBaseline />
             <App />
         </ThemeProvider>
-    </StrictMode>,
+    </StrictMode>
 );

--- a/packages/client/tsconfig.json
+++ b/packages/client/tsconfig.json
@@ -6,14 +6,16 @@
         "isolatedModules": true, // 각 파일을 개별 모듈 처리
         "allowImportingTsExtensions": true, // ts 파일을 import 할 수 있도록 설정
         "noEmit": true, // 컴파일러가 javascript 출력 파일을 생성하지 않음
+        "allowSyntheticDefaultImports": true, // default import 허용
         "baseUrl": ".",
         "paths": {
             "@components/*": ["src/components/*"],
-            "@theme/*": ["src/theme/*"],
             "@hooks/*": ["src/hooks/*"],
+            "@utils/*": ["src/utils/*"],
+            "@types": ["src/types/index.ts"],
+            "@theme": ["src/theme/index.ts"],
             "@/*": ["*"]
-        },
-        "allowSyntheticDefaultImports": true // default import 허용
+        }
     },
     "include": ["src"]
 }

--- a/packages/client/tsconfig.json
+++ b/packages/client/tsconfig.json
@@ -10,6 +10,7 @@
         "paths": {
             "@components/*": ["src/components/*"],
             "@theme/*": ["src/theme/*"],
+            "@hooks/*": ["src/hooks/*"],
             "@/*": ["*"]
         },
         "allowSyntheticDefaultImports": true // default import 허용


### PR DESCRIPTION

https://github.com/user-attachments/assets/121a3ee1-52cc-4fa3-aa4f-440576173554


# 기능
- zoom pan 드래그 화면 이동 
- zoom pan 줌인 / 줌 아웃 

# 문제
- 화면 확대/축소 `svg`의 `viewBox`를 통해서 구현
- 화면 확대/축소 상황에서  화면 이동에 문제가 있었음
   - `svg`의 `viewBox`에 대응되는 거리와 크기의 비율을 구하여 줌인/줌아웃이 되었을 때도 비율에 따라 화면 움직임에 대한 보정을 해줌
