### PR TITLE
#2 노드간의 거리를 계산하여 자동으로 제일 가까운 anchor로 edge 지점을 변경

### DIFF
--- a/apps/client/mocks/instance.ts
+++ b/apps/client/mocks/instance.ts
@@ -32,7 +32,7 @@ export const createMockNodesAndEdges = (
 
         return {
             id: nanoid(),
-            type: 'line',
+            type: 'arrow',
             source: {
                 ...nodes[sourceIndex],
                 anchorType: randomAnchorType() as AnchorType,

--- a/apps/client/src/cloudflow/components/Edge/index.tsx
+++ b/apps/client/src/cloudflow/components/Edge/index.tsx
@@ -62,7 +62,7 @@ export default memo(
                     y2={targetPoint.y}
                     stroke={
                         isSelected
-                            ? theme.palette.error.main
+                            ? theme.palette.info.main
                             : theme.palette.text.primary
                     }
                     strokeWidth={3}

--- a/apps/client/src/cloudflow/components/Node/index.tsx
+++ b/apps/client/src/cloudflow/components/Node/index.tsx
@@ -52,6 +52,7 @@ export default memo(
             <g
                 id={id}
                 data-type="flow-node"
+                data-node-type={type}
                 style={{ transform: `translate(${point.x}px, ${point.y}px)` }}
                 onMouseDown={handleMouseDown}
                 onDoubleClick={handleDbClick}

--- a/apps/client/src/cloudflow/contexts/EdgeContext/reducer.ts
+++ b/apps/client/src/cloudflow/contexts/EdgeContext/reducer.ts
@@ -11,6 +11,7 @@ export const initialEdgeState: EdgeState = {
 
 export type EdgeAction =
     | { type: 'ADD_EDGE'; payload: Edge }
+    | { type: 'UPDATE_EDGE'; payload: { edgeId: string; data: Partial<Edge> } }
     | { type: 'REMOVE_EDGE'; payload: { edgeId: string } }
     | {
           type: 'SPLIT_EDGE';
@@ -27,6 +28,19 @@ export const edgeReducer = (
     switch (action.type) {
         case 'ADD_EDGE':
             return { ...state, edges: [...state.edges, action.payload] };
+        case 'UPDATE_EDGE':
+            return {
+                ...state,
+                edges: state.edges.map((edge) => {
+                    if (edge.id === action.payload.edgeId) {
+                        return {
+                            ...edge,
+                            ...action.payload.data,
+                        };
+                    }
+                    return edge;
+                }),
+            };
         case 'REMOVE_EDGE': {
             const edgeToRemove = state.edges.find(
                 (edge) => edge.id === action.payload.edgeId,

--- a/apps/client/src/cloudflow/contexts/EdgeContext/reducer.ts
+++ b/apps/client/src/cloudflow/contexts/EdgeContext/reducer.ts
@@ -11,6 +11,7 @@ export const initialEdgeState: EdgeState = {
 
 export type EdgeAction =
     | { type: 'ADD_EDGE'; payload: Edge }
+    | { type: 'REMOVE_EDGE'; payload: { edgeId: string } }
     | {
           type: 'SPLIT_EDGE';
           payload: {
@@ -25,7 +26,60 @@ export const edgeReducer = (
 ): EdgeState => {
     switch (action.type) {
         case 'ADD_EDGE':
-            return { edges: [...state.edges, action.payload] };
+            return { ...state, edges: [...state.edges, action.payload] };
+        case 'REMOVE_EDGE': {
+            const edgeToRemove = state.edges.find(
+                (edge) => edge.id === action.payload.edgeId,
+            );
+            if (!edgeToRemove) return state;
+
+            const { source, target } = edgeToRemove;
+
+            let newEdges = state.edges.filter(
+                (edge) => edge.id !== action.payload.edgeId,
+            );
+
+            //INFO: source.type === 'pointer' && target.type ==='pointer'조건도 target pointer로 위치를 변경하여
+            //source.type ==='pointer'와 조건이 동일
+            if (source.type === 'pointer') {
+                const sourceEdge = state.edges.find(
+                    (edge) => edge.target.id === source.id,
+                );
+                newEdges = newEdges.map((edge) => {
+                    if (sourceEdge && edge.id === sourceEdge.id) {
+                        return {
+                            ...edge,
+                            target: edgeToRemove.target,
+                            type:
+                                edgeToRemove.target.type === 'pointer'
+                                    ? 'line'
+                                    : 'arrow',
+                        };
+                    }
+
+                    return edge;
+                });
+            } else if (target.type === 'pointer') {
+                const targetEdge = state.edges.find(
+                    (edge) => edge.source.id === target.id,
+                );
+
+                newEdges = newEdges.map((edge) => {
+                    if (targetEdge && edge.id === targetEdge.id) {
+                        return {
+                            ...edge,
+                            source: edgeToRemove.source,
+                        };
+                    }
+                    return edge;
+                });
+            }
+
+            return {
+                ...state,
+                edges: newEdges,
+            };
+        }
         case 'SPLIT_EDGE': {
             const { edgeId, pointer } = action.payload;
             const sourceEdge = state.edges.find((edge) => edge.id === edgeId);

--- a/apps/client/src/cloudflow/contexts/EdgeContext/reducer.ts
+++ b/apps/client/src/cloudflow/contexts/EdgeContext/reducer.ts
@@ -96,7 +96,7 @@ export const edgeReducer = (
                 id: nanoid(),
                 source: pointer,
                 target,
-                type: 'arrow',
+                type: target.type === 'pointer' ? 'line' : 'arrow',
             };
 
             return {

--- a/apps/client/src/cloudflow/contexts/NodeContext/reducer.ts
+++ b/apps/client/src/cloudflow/contexts/NodeContext/reducer.ts
@@ -6,6 +6,7 @@ export type NodeState = {
 
 export type NodeAction =
     | { type: 'ADD_NODE'; payload: Node }
+    | { type: 'REMOVE_NODE'; payload: { nodeId: string } }
     | {
           type: 'MOVE_NODE';
           payload: Pick<Node, 'id' | 'point'>;
@@ -17,18 +18,25 @@ export const initialNodeState: NodeState = {
 
 export const nodeReducer = (
     state: NodeState,
-    action: NodeAction
+    action: NodeAction,
 ): NodeState => {
     switch (action.type) {
         case 'ADD_NODE':
             return { ...state, nodes: [...state.nodes, action.payload] };
+        case 'REMOVE_NODE':
+            return {
+                ...state,
+                nodes: state.nodes.filter(
+                    (node) => node.id !== action.payload.nodeId,
+                ),
+            };
         case 'MOVE_NODE':
             return {
                 ...state,
                 nodes: state.nodes.map((node) =>
                     node.id === action.payload.id
                         ? { ...node, point: action.payload.point }
-                        : node
+                        : node,
                 ),
             };
         default:

--- a/apps/client/src/cloudflow/hooks/useDragNode.ts
+++ b/apps/client/src/cloudflow/hooks/useDragNode.ts
@@ -18,10 +18,7 @@ export default (flowRef: RefObject<SVGSVGElement>, dimension: Dimension) => {
         state: { edges },
         dispatch: dispatchEdge,
     } = useEdgeContext();
-    const {
-        state: { nodes },
-        dispatch: dispatchNode,
-    } = useNodeContext();
+    const { dispatch: dispatchNode } = useNodeContext();
     const startDragPoint = useRef<Point | null>(null);
 
     const [draggingId, setDraggingId] = useState<string | null>(null);
@@ -121,7 +118,11 @@ export default (flowRef: RefObject<SVGSVGElement>, dimension: Dimension) => {
                     },
                 });
 
-                updateEdgesToNearestAnchors(newPoint);
+                if (
+                    (nodeElement as SVGGElement).dataset.nodeType !== 'pointer'
+                ) {
+                    updateEdgesToNearestAnchors(newPoint);
+                }
             }
         },
         [isDragging, draggingId, dimension],

--- a/apps/client/src/cloudflow/index.tsx
+++ b/apps/client/src/cloudflow/index.tsx
@@ -81,45 +81,48 @@ export const SvgFlow = () => {
     }, [isDragging, isPanning]);
 
     useEffect(() => {
+        const removeNode = (nodeId: string) => {
+            dispatchNode({
+                type: 'REMOVE_NODE',
+                payload: { nodeId },
+            });
+        };
+
+        const removeEdge = (edgeId: string) => {
+            const edge = edges.find((edge) => edge.id === edgeId);
+            if (!edge) return;
+            const { source, target } = edge!;
+            if (target.type === 'pointer' && source.type === 'pointer') {
+                dispatchNode({
+                    type: 'REMOVE_NODE',
+                    payload: { nodeId: source.id },
+                });
+            } else if (target.type === 'pointer') {
+                dispatchNode({
+                    type: 'REMOVE_NODE',
+                    payload: { nodeId: target.id },
+                });
+            } else if (source.type === 'pointer') {
+                dispatchNode({
+                    type: 'REMOVE_NODE',
+                    payload: { nodeId: source.id },
+                });
+            }
+
+            dispatchEdge({
+                type: 'REMOVE_EDGE',
+                payload: { edgeId },
+            });
+        };
+
         const handleKeyDown = (event: KeyboardEvent) => {
             if (event.key === 'Backspace') {
                 if (selectedNodeId) {
-                    dispatchNode({
-                        type: 'REMOVE_NODE',
-                        payload: { nodeId: selectedNodeId },
-                    });
+                    removeNode(selectedNodeId);
                 }
 
                 if (selectedEdgeId) {
-                    const edge = edges.find(
-                        (edge) => edge.id === selectedEdgeId,
-                    );
-                    if (!edge) return;
-                    const { source, target } = edge!;
-                    if (
-                        target.type === 'pointer' &&
-                        source.type === 'pointer'
-                    ) {
-                        dispatchNode({
-                            type: 'REMOVE_NODE',
-                            payload: { nodeId: source.id },
-                        });
-                    } else if (target.type === 'pointer') {
-                        dispatchNode({
-                            type: 'REMOVE_NODE',
-                            payload: { nodeId: target.id },
-                        });
-                    } else if (source.type === 'pointer') {
-                        dispatchNode({
-                            type: 'REMOVE_NODE',
-                            payload: { nodeId: source.id },
-                        });
-                    }
-
-                    dispatchEdge({
-                        type: 'REMOVE_EDGE',
-                        payload: { edgeId: selectedEdgeId },
-                    });
+                    removeEdge(selectedEdgeId);
                 }
             }
         };

--- a/apps/client/src/cloudflow/types/index.ts
+++ b/apps/client/src/cloudflow/types/index.ts
@@ -34,3 +34,5 @@ export type Connection = {
 
 export type CommonNodeType = 'pointer';
 export type CloudNodeType = 'server';
+
+export type AnchorsPoint = Record<AnchorType, Point>;

--- a/apps/client/src/cloudflow/utils/index.ts
+++ b/apps/client/src/cloudflow/utils/index.ts
@@ -4,7 +4,7 @@ import {
     GRID_3D_WIDTH_SIZE,
     GRID_SIZE,
 } from '@cloudflow/constants';
-import { AnchorType, Dimension, Point } from '@cloudflow/types';
+import { AnchorsPoint, Dimension, Point } from '@cloudflow/types';
 
 export const getDistance = (point1: Point, point2: Point) => {
     return Math.sqrt((point1.x - point2.x) ** 2 + (point1.y - point2.y) ** 2);
@@ -31,7 +31,7 @@ export const getNodeSizeForDimension = (dimension: Dimension) => {
 export const calculateAnchorPoints = (
     point: Point,
     dimension: Dimension,
-): Record<AnchorType, Point> => {
+): AnchorsPoint => {
     const { width, height } = getNodeSizeForDimension(dimension);
 
     return {


### PR DESCRIPTION
https://github.com/user-attachments/assets/58196353-13e8-4408-861a-098da8083127

- 노드를 움직일 시 가장 노드간 연결되어있는 edge의 anchor 지점을 가장 가까운 지점으로 이동 기능 구현
- 간선 시작,끝 지점 모두 자동으로 가장 가까운 anchor로 edge지점을 변경함
### Todo
- 노드 움직임의 성능 향상을 위해 requestAnimationFrame 적용 필요