### PR TITLE
3D Svg 

### DIFF
--- a/apps/client/mocks/instance.ts
+++ b/apps/client/mocks/instance.ts
@@ -18,7 +18,7 @@ export const createMockNodesAndEdges = (
     edgeCount: number,
 ) => {
     const nodes: Node[] = Array.from({ length: nodeCount }, () => ({
-        id: nanoid(),
+        id: 'mock'.concat(nanoid()),
         type: 'server',
         point: getRandomPoint(),
     }));

--- a/apps/client/src/cloudflow/components/Flow/index.tsx
+++ b/apps/client/src/cloudflow/components/Flow/index.tsx
@@ -69,6 +69,7 @@ export default forwardRef<SVGSVGElement, Props>(
         };
         return (
             <svg
+                id="cloudflow"
                 ref={ref}
                 width="100%"
                 height="100%"

--- a/apps/client/src/cloudflow/contexts/FlowCotext/index.tsx
+++ b/apps/client/src/cloudflow/contexts/FlowCotext/index.tsx
@@ -15,18 +15,24 @@ type FlowContextProps = {
 };
 const FlowContext = createContext<FlowContextProps>({
     flowRef: { current: null },
-    dimension: '2d',
+    dimension: '3d',
     changeDimension: () => {},
 });
 
 export const FlowProvider = ({ children }: PropsWithChildren) => {
     const flowRef = useRef<SVGSVGElement>(null);
-    const [dimension, setDimension] = useState<Dimension>('2d');
+    const [dimension, setDimension] = useState<Dimension>('3d');
 
     const changeDimension = (dimension: Dimension) => setDimension(dimension);
 
     return (
-        <FlowContext.Provider value={{ flowRef, dimension, changeDimension }}>
+        <FlowContext.Provider
+            value={{
+                flowRef,
+                dimension,
+                changeDimension,
+            }}
+        >
             {children}
         </FlowContext.Provider>
     );

--- a/apps/client/src/cloudflow/contexts/FlowCotext/index.tsx
+++ b/apps/client/src/cloudflow/contexts/FlowCotext/index.tsx
@@ -21,7 +21,7 @@ const FlowContext = createContext<FlowContextProps>({
 
 export const FlowProvider = ({ children }: PropsWithChildren) => {
     const flowRef = useRef<SVGSVGElement>(null);
-    const [dimension, setDimension] = useState<Dimension>('3d');
+    const [dimension, setDimension] = useState<Dimension>('2d');
 
     const changeDimension = (dimension: Dimension) => setDimension(dimension);
 

--- a/apps/client/src/cloudflow/contexts/NodeContext/reducer.ts
+++ b/apps/client/src/cloudflow/contexts/NodeContext/reducer.ts
@@ -33,11 +33,19 @@ export const nodeReducer = (
         case 'MOVE_NODE':
             return {
                 ...state,
-                nodes: state.nodes.map((node) =>
-                    node.id === action.payload.id
-                        ? { ...node, point: action.payload.point }
-                        : node,
-                ),
+                nodes: state.nodes
+                    .map((node) =>
+                        node.id === action.payload.id
+                            ? { ...node, point: action.payload.point }
+                            : node,
+                    )
+                    .sort((a, b) => {
+                        if (a.point.y === b.point.y) {
+                            return a.point.x - b.point.x;
+                        } else {
+                            return a.point.y - b.point.y;
+                        }
+                    }),
             };
         default:
             return state;

--- a/apps/client/src/cloudflow/hooks/useDragNode.ts
+++ b/apps/client/src/cloudflow/hooks/useDragNode.ts
@@ -106,43 +106,6 @@ export default (flowRef: RefObject<SVGSVGElement>, dimension: Dimension) => {
                 ) {
                     updateEdgesToNearestAnchors(newPoint);
                 }
-
-                //INFO:3D에 관련되어 svg간의 위치를 조정하는 코드, 리팩토링이 필요함
-                const nodes = flowRef!.current.querySelector('#flow-nodes');
-                const otherNodes = Array.from(nodes!.children).filter(
-                    (child) => child.id !== draggingId,
-                ) as SVGGraphicsElement[];
-
-                const getNodePointFromTransform = (
-                    node: SVGGraphicsElement,
-                ) => {
-                    const transform = node.style.transform;
-                    const regex = /translate\(([-\d.]+)px,\s*([-\d.]+)px\)/;
-                    const match = transform.match(regex);
-                    if (!match) return { x: 0, y: 0 };
-                    return {
-                        x: parseFloat(match[1]),
-                        y: parseFloat(match[2]),
-                    };
-                };
-
-                otherNodes.forEach((otherNode) => {
-                    const otherNodePoint = getNodePointFromTransform(otherNode);
-                    const draggingNodePoint =
-                        getNodePointFromTransform(nodeElement);
-
-                    if (otherNodePoint.y === draggingNodePoint.y) {
-                        if (otherNodePoint.x < draggingNodePoint.x) {
-                            nodeElement.parentNode!.appendChild(nodeElement);
-                        } else {
-                            otherNode.parentNode!.appendChild(otherNode);
-                        }
-                    } else if (otherNodePoint.y < draggingNodePoint.y) {
-                        nodeElement.parentNode!.appendChild(nodeElement);
-                    } else {
-                        otherNode.parentNode!.appendChild(otherNode);
-                    }
-                });
             }
         },
         [isDragging, draggingId, dimension],

--- a/apps/client/src/cloudflow/hooks/useDragNode.ts
+++ b/apps/client/src/cloudflow/hooks/useDragNode.ts
@@ -1,8 +1,4 @@
-import {
-    GRID_3D_HEIGHT_SIZE,
-    GRID_3D_WIDTH_SIZE,
-    GRID_SIZE,
-} from '@cloudflow/constants';
+import { GRID_SIZE } from '@cloudflow/constants';
 import { useEdgeContext } from '@cloudflow/contexts/EdgeContext';
 import { useNodeContext } from '@cloudflow/contexts/NodeContext';
 import { AnchorsPoint, AnchorType, Dimension, Point } from '@cloudflow/types';
@@ -10,6 +6,8 @@ import {
     calculateAnchorPoints,
     getDistance,
     getSvgPoint,
+    gridToScreen,
+    screenToGrid,
 } from '@cloudflow/utils';
 import { RefObject, useCallback, useRef, useState } from 'react';
 
@@ -23,23 +21,6 @@ export default (flowRef: RefObject<SVGSVGElement>, dimension: Dimension) => {
 
     const [draggingId, setDraggingId] = useState<string | null>(null);
     const [isDragging, setIsDragging] = useState(false);
-
-    const gridToScreen = (col: number, row: number): Point => {
-        const x = (col - row) * (GRID_3D_WIDTH_SIZE / 2);
-        const y = (col + row) * (GRID_3D_HEIGHT_SIZE / 2);
-        return { x, y };
-    };
-
-    const screenToGrid = (
-        x: number,
-        y: number,
-    ): { col: number; row: number } => {
-        const col =
-            (x / (GRID_3D_WIDTH_SIZE / 2) + y / (GRID_3D_HEIGHT_SIZE / 2)) / 2;
-        const row =
-            (y / (GRID_3D_HEIGHT_SIZE / 2) - x / (GRID_3D_WIDTH_SIZE / 2)) / 2;
-        return { col, row };
-    };
 
     const getGridAlignedPoint = (
         cursorPoint: Point,
@@ -66,7 +47,7 @@ export default (flowRef: RefObject<SVGSVGElement>, dimension: Dimension) => {
 
             return gridToScreen(snappedCol, snappedRow);
         } else {
-            throw new Error('Invalid dimension');
+            throw new Error('only support 2d and 3d dimension');
         }
     };
 

--- a/apps/client/src/cloudflow/hooks/useDragNode.ts
+++ b/apps/client/src/cloudflow/hooks/useDragNode.ts
@@ -214,6 +214,11 @@ export default (flowRef: RefObject<SVGSVGElement>, dimension: Dimension) => {
                 connectedAnchorPoints,
             );
 
+            // 포인터일 경우 anchorType을 변경하지 않음
+            if (target.type === 'pointer' || source.type === 'pointer') {
+                nearestAnchorPair.connectedAnchorType = null;
+            }
+
             dispatchEdge({
                 type: 'UPDATE_EDGE',
                 payload: {

--- a/apps/client/src/cloudflow/hooks/useMocks.ts
+++ b/apps/client/src/cloudflow/hooks/useMocks.ts
@@ -11,7 +11,7 @@ export default () => {
     const [mockEdges, setMockEdges] = useState<Edge[]>([]);
 
     useEffect(() => {
-        const { nodes, edges } = createMockNodesAndEdges(4, 5);
+        const { nodes, edges } = createMockNodesAndEdges(50, 50);
         setMockNodes(nodes);
         setMockEdges(edges);
     }, []);

--- a/apps/client/src/cloudflow/hooks/useMocks.ts
+++ b/apps/client/src/cloudflow/hooks/useMocks.ts
@@ -11,7 +11,7 @@ export default () => {
     const [mockEdges, setMockEdges] = useState<Edge[]>([]);
 
     useEffect(() => {
-        const { nodes, edges } = createMockNodesAndEdges(50, 50);
+        const { nodes, edges } = createMockNodesAndEdges(200, 50);
         setMockNodes(nodes);
         setMockEdges(edges);
     }, []);

--- a/apps/client/src/cloudflow/hooks/useMocks.ts
+++ b/apps/client/src/cloudflow/hooks/useMocks.ts
@@ -1,26 +1,34 @@
 import { createMockNodesAndEdges } from '@/mocks/instance';
 import { useEdgeContext } from '@cloudflow/contexts/EdgeContext';
 import { useNodeContext } from '@cloudflow/contexts/NodeContext';
-import { useEffect } from 'react';
+import { Edge, Node } from '@cloudflow/types';
+import { useEffect, useState } from 'react';
 
 export default () => {
     const { dispatch: dispatchEdge } = useEdgeContext();
     const { dispatch: dispatchNode } = useNodeContext();
+    const [mockNodes, setMockNodes] = useState<Node[]>([]);
+    const [mockEdges, setMockEdges] = useState<Edge[]>([]);
 
     useEffect(() => {
-        const { nodes, edges } = createMockNodesAndEdges(100, 100);
-        nodes.forEach((node) => {
+        const { nodes, edges } = createMockNodesAndEdges(4, 5);
+        setMockNodes(nodes);
+        setMockEdges(edges);
+    }, []);
+
+    useEffect(() => {
+        mockNodes.forEach((node) => {
             dispatchNode({
                 type: 'ADD_NODE',
                 payload: node,
             });
         });
 
-        edges.forEach((edge) => {
+        mockEdges.forEach((edge) => {
             dispatchEdge({
                 type: 'ADD_EDGE',
                 payload: edge,
             });
         });
-    }, []);
+    }, [mockNodes, mockEdges]);
 };

--- a/apps/client/src/cloudflow/index.tsx
+++ b/apps/client/src/cloudflow/index.tsx
@@ -162,7 +162,7 @@ export const SvgFlow = () => {
                 ))}
             </g>
 
-            <g id="flow-dnoes">
+            <g id="flow-nodes">
                 {visibleCloudNode.map((node) => (
                     <Node
                         key={node.id}

--- a/apps/client/src/cloudflow/index.tsx
+++ b/apps/client/src/cloudflow/index.tsx
@@ -149,28 +149,32 @@ export const SvgFlow = () => {
             onEndConnect={handleEndConnect}
             onDeSelectNode={handleDeSelectNode}
         >
-            {visibleEdges.map((edge) => (
-                <Edge
-                    key={edge.id}
-                    edge={edge}
-                    dimension={dimension}
-                    isSelected={edge.id === selectedEdgeId}
-                    onSplitEdge={handleSplitEdge}
-                    onSelectEdge={handleSelectEdge}
-                />
-            ))}
+            <g id="flow-edges">
+                {visibleEdges.map((edge) => (
+                    <Edge
+                        key={edge.id}
+                        edge={edge}
+                        dimension={dimension}
+                        isSelected={edge.id === selectedEdgeId}
+                        onSplitEdge={handleSplitEdge}
+                        onSelectEdge={handleSelectEdge}
+                    />
+                ))}
+            </g>
 
-            {visibleCloudNode.map((node) => (
-                <Node
-                    key={node.id}
-                    node={node}
-                    dimension={dimension}
-                    isSelected={node.id === selectedNodeId}
-                    onStartDragNode={handleStartDragNode}
-                    onSelectNode={handleSelectNode}
-                    onStartConnect={handleStartConnect}
-                />
-            ))}
+            <g id="flow-dnoes">
+                {visibleCloudNode.map((node) => (
+                    <Node
+                        key={node.id}
+                        node={node}
+                        dimension={dimension}
+                        isSelected={node.id === selectedNodeId}
+                        onStartDragNode={handleStartDragNode}
+                        onSelectNode={handleSelectNode}
+                        onStartConnect={handleStartConnect}
+                    />
+                ))}
+            </g>
 
             {isConnecting && connection && connection.target && (
                 <Connector

--- a/apps/client/src/cloudflow/utils/index.ts
+++ b/apps/client/src/cloudflow/utils/index.ts
@@ -41,3 +41,38 @@ export const calculateAnchorPoints = (
         left: { x: point.x, y: point.y + height / 2 },
     };
 };
+
+export const gridToScreen = (col: number, row: number): Point => {
+    const x = (col - row) * (GRID_3D_WIDTH_SIZE / 2);
+    const y = (col + row) * (GRID_3D_HEIGHT_SIZE / 2);
+    return { x, y };
+};
+
+export const screenToGrid = (
+    x: number,
+    y: number,
+): { col: number; row: number } => {
+    const col =
+        (x / (GRID_3D_WIDTH_SIZE / 2) + y / (GRID_3D_HEIGHT_SIZE / 2)) / 2;
+    const row =
+        (y / (GRID_3D_HEIGHT_SIZE / 2) - x / (GRID_3D_WIDTH_SIZE / 2)) / 2;
+    return { col, row };
+};
+
+export const getGridAlignedPoint = (point: Point, dimension: Dimension) => {
+    const snappedSize = dimension === '2d' ? GRID_SIZE / 4 : 1 / 4;
+
+    if (dimension === '2d') {
+        const gridAlignedX = Math.round(point.x / snappedSize) * snappedSize;
+        const gridAlignedY = Math.round(point.y / snappedSize) * snappedSize;
+
+        return screenToGrid(gridAlignedX, gridAlignedY);
+    }
+
+    const { col, row } = screenToGrid(point.x, point.y);
+
+    const snappedCol = Math.round(col / snappedSize) * snappedSize;
+    const snappedRow = Math.round(row / snappedSize) * snappedSize;
+
+    return { col: snappedCol, row: snappedRow };
+};


### PR DESCRIPTION

## 문제


https://github.com/user-attachments/assets/8f4e368c-8890-43bd-bc65-b9939cc45729


## 해결
https://github.com/user-attachments/assets/3da91a80-ee1f-4bca-89fc-ddb4dfb38d98




- 아이소메트릭을 이용한 2D기반 3D 구현
- Svg는 DOM위치에 따라 레아이웃(Z축) 위치가 달라짐으로 인해 노드 움직일 시 sort를 통해 svg 위치를 변경

### 문제 해결
노드를 드래그 앤 드랍을 할 때마다 sort를 하는 과정이 좋지 못한 과정이라 생각했습니다. 따라서 Map을 이용하여 노드 위치를 기반하는 데이터 구조를 만들어서 충돌을 감지하는 로직을 작성했지만 완벽히 원하는 충돌을 감지하기가 쉽지 않았습니다.
```typescript
export type GridPoint = {
    row: number;
    col: number;
};


const getKey = (point: GridPoint) => `${point.col},${point.row}`;

const addNodeToVirtualGrid = (nodeId: string, point: GridPoint) => {
    const key = getKey(point);
    const nodeIds = virtualGrid.current.get(key);
    virtualGrid.current.set(key, nodeIds ? [...nodeIds, nodeId] : [nodeId]);
    nodeToGridMap.current.set(nodeId, point);
};

const removeNodeFromVirtualGrid = (nodeId: string) => {
    const point = nodeToGridMap.current.get(nodeId);
    if (!point) return;

    const key = getKey(point);
    const nodeIds = virtualGrid.current.get(key);
    if (nodeIds) {
        if (nodeIds.length === 1) {
            virtualGrid.current.delete(key);
        } else {
            virtualGrid.current.set(
                key,
                nodeIds.filter((id) => id !== nodeId),
            );
        }
    }
    nodeToGridMap.current.delete(nodeId);
};

const moveNodeInVirtualGrid = (id: string, point: GridPoint) => {
    removeNodeFromVirtualGrid(id);

    const nextKey = getKey(point);
    const nextNodeIds = virtualGrid.current.get(nextKey);
    virtualGrid.current.set(
        nextKey,
        nextNodeIds ? [...nextNodeIds, id] : [id],
    );

    nodeToGridMap.current.set(id, point);
};

const getCollisionNodes = (
    point: GridPoint,
    snappedSize: number,
): string[] => {
    const direction = [
        [0, 1],
        [1, 0],
        [-1, 0],
        [0, -1],
        [1, 1],
        [-1, 1],
        [1, -1],
        [-1, -1],
    ];

    const collisionNodes: string[] = [];

    direction.forEach(([dx, dy]) => {
        for (let i = 1; i <= 4; i++) {
            const key = getKey({
                col: point.col + dx * i * snappedSize,
                row: point.row + dy * i * snappedSize,
            });
            const nodeIds = virtualGrid.current.get(key);
            if (nodeIds) {
                collisionNodes.push(...nodeIds);
            }
        }
    });

    console.log(collisionNodes);
    return collisionNodes;
};
```

따라서 노드의 움직임을 transform으로 조작하기 떄문에 style의 transform을 가져와서 x,y축을 기반으로 드래그한 노드가 다른 노드들 보다 아래에 위치하는지 위에 위치하는지를 계산하여 DOM을 직접 다루어 조작을 했지만 Context를 이용하여 관리하는 nodes데이터를 변경하지 않았기 떄문에 리렌더링이 발생하면 위치가 원상복구 되는 문제가 있었습니다.

```typescript
const nodes = flowRef!.current.querySelector('#flow-nodes');
const otherNodes = Array.from(nodes!.children).filter(
    (child) => child.id !== draggingId,
) as SVGGraphicsElement[];

const getNodePointFromTransform = (
    node: SVGGraphicsElement,
) => {
    const transform = node.style.transform;
    const regex = /translate\(([-\d.]+)px,\s*([-\d.]+)px\)/;
    const match = transform.match(regex);
    if (!match) return { x: 0, y: 0 };
    return {
        x: parseFloat(match[1]),
        y: parseFloat(match[2]),
    };
};

otherNodes.forEach((otherNode) => {
    const otherNodePoint = getNodePointFromTransform(otherNode);
    const draggingNodePoint =
        getNodePointFromTransform(nodeElement);

    if (otherNodePoint.y === draggingNodePoint.y) {
        if (otherNodePoint.x < draggingNodePoint.x) {
            nodeElement.parentNode!.appendChild(nodeElement);
        } else {
            otherNode.parentNode!.appendChild(otherNode);
        }
    } else if (otherNodePoint.y < draggingNodePoint.y) {
        nodeElement.parentNode!.appendChild(nodeElement);
    } else {
        otherNode.parentNode!.appendChild(otherNode);
    }
});
```

결국 처음에 가장 간단하고 쉬운 움직일 시 nodes변수를 sort하는 방법으로 채택을 했습니다. javascript는 tim sort를 사용하기 때문에 O(n log n) 시간복잡도를 가지는데 전체 노드가 100이상 까지는 다루지 않겠다고 판단하여 가장 쉬운 방법을 사용했습니다.