### PR TITLE
LoadBalancer, MySQL 모델 리팩토링 및 ObjectStroage, Redis 모델 파싱 추가

### DIFF
--- a/packages/terraform/converter/TerraformConverter.ts
+++ b/packages/terraform/converter/TerraformConverter.ts
@@ -1,12 +1,11 @@
 import { ResourceManager } from '../type/ResourceManager';
 import { CodeGenerator } from '../type/TerraformGenerator';
 import { NCloudProvider } from '../model/NCloudProvider';
-import { CloudCanvasNode } from '../interface/CloudCanvasNode';
 import { parseToNCloudModel } from '../util/resourceParser';
 import { processNodes } from '../util/resource';
 import { collectRegions, createProvider } from '../util/provider';
 
-export class TerraformConvertor {
+export class TerraformConverter {
     private readonly resourceManager: ResourceManager;
     private readonly codeGenerator: CodeGenerator;
     private providers: Map<string, NCloudProvider>;
@@ -17,7 +16,10 @@ export class TerraformConvertor {
         this.providers = new Map();
     }
 
-    addResourceFromJson(node: any): void {
+    addResourceFromJson(node: { [key: string]: any }): void {
+        if (!node) {
+            throw new Error('Invalid node');
+        }
         const nodes = processNodes([node]);
         const regions = collectRegions(nodes);
 

--- a/packages/terraform/converter/TerraformConverter.ts
+++ b/packages/terraform/converter/TerraformConverter.ts
@@ -16,11 +16,11 @@ export class TerraformConverter {
         this.providers = new Map();
     }
 
-    addResourceFromJson(node: { [key: string]: any }): void {
+    addResourceFromJson(node: { [key: string]: any }[]): void {
         if (!node) {
             throw new Error('Invalid node');
         }
-        const nodes = processNodes([node]);
+        const nodes = processNodes(node);
         const regions = collectRegions(nodes);
 
         regions.forEach((region) => {

--- a/packages/terraform/enum/ResourcePriority.ts
+++ b/packages/terraform/enum/ResourcePriority.ts
@@ -12,4 +12,6 @@ export enum ResourcePriority {
     LAUNCH_CONFIGURATION = 11,
     MYSQL = 12,
     OBJECT_STORAGE_BUCKET = 13,
+    REDIS = 14,
+    REDIS_CONFIG_GROUP = 15,
 }

--- a/packages/terraform/enum/ResourcePriority.ts
+++ b/packages/terraform/enum/ResourcePriority.ts
@@ -11,4 +11,5 @@ export enum ResourcePriority {
     LOAD_BALANCER = 10,
     LAUNCH_CONFIGURATION = 11,
     MYSQL = 12,
+    OBJECT_STORAGE_BUCKET = 13,
 }

--- a/packages/terraform/interface/ACG.ts
+++ b/packages/terraform/interface/ACG.ts
@@ -1,6 +1,5 @@
 export interface ACG {
     id: string;
     vpcNo: string;
-    name?: string;
     isDefault?: boolean;
 }

--- a/packages/terraform/interface/LaunchConfiguration.ts
+++ b/packages/terraform/interface/LaunchConfiguration.ts
@@ -1,6 +1,5 @@
 export interface LaunchConfiguration {
     id: string;
-    name: string;
     serverImageProductCode?: string;
     serverProductCode?: string;
     memberServerImageNo?: string;

--- a/packages/terraform/interface/LoadBalancer.ts
+++ b/packages/terraform/interface/LoadBalancer.ts
@@ -1,6 +1,5 @@
 export interface LoadBalancer {
     id: string;
-    name: string;
     networkType: string;
     type: string;
     subnetNoList: string[];

--- a/packages/terraform/interface/LoginKey.ts
+++ b/packages/terraform/interface/LoginKey.ts
@@ -1,5 +1,4 @@
 export interface LoginKey {
-    name: string;
     privateKey?: string;
     fingerprint?: string;
 }

--- a/packages/terraform/interface/NetworkACL.ts
+++ b/packages/terraform/interface/NetworkACL.ts
@@ -1,5 +1,4 @@
 export interface NetworkACL {
     id: string;
-    name: string;
     vpcNo: string;
 }

--- a/packages/terraform/interface/NetworkInterface.ts
+++ b/packages/terraform/interface/NetworkInterface.ts
@@ -1,6 +1,5 @@
 export interface NetworkInterface {
     id: string;
-    name: string;
     subnetNo: string;
     accessControlGroups: string[];
 }

--- a/packages/terraform/interface/ObjectStorageBucket.ts
+++ b/packages/terraform/interface/ObjectStorageBucket.ts
@@ -1,0 +1,3 @@
+export interface ObjectStorageBucket {
+    bucketName: string;
+}

--- a/packages/terraform/interface/PublicIp.ts
+++ b/packages/terraform/interface/PublicIp.ts
@@ -1,6 +1,5 @@
 export interface PublicIp {
     id: string;
-    name: string;
     serverInstanceNo?: string;
     publicIp?: string;
     kindType?: string;

--- a/packages/terraform/interface/Redis.ts
+++ b/packages/terraform/interface/Redis.ts
@@ -1,0 +1,8 @@
+export interface Redis {
+    serviceName: string;
+    serverNamePrefix: string;
+    vpcNo: string;
+    subnetNo: string;
+    configGroupNo: string;
+    mode: string;
+}

--- a/packages/terraform/interface/RedisConfigGroup.ts
+++ b/packages/terraform/interface/RedisConfigGroup.ts
@@ -1,0 +1,4 @@
+export interface RedisConfigGroup {
+    redisVersion: string;
+    description?: string;
+}

--- a/packages/terraform/interface/Server.ts
+++ b/packages/terraform/interface/Server.ts
@@ -1,6 +1,5 @@
 export interface Server {
     id: string;
-    name: string;
     subnetNo: string;
     serverImageNumber: string;
     serverSpecCode: string;

--- a/packages/terraform/interface/Subnet.ts
+++ b/packages/terraform/interface/Subnet.ts
@@ -5,6 +5,5 @@ export interface Subnet {
     zone: string;
     networkAclNo: string;
     subnetType: 'PUBLIC' | 'PRIVATE';
-    name?: string;
     usageType?: 'GEN' | 'LOADB' | 'BM' | 'NATGW';
 }

--- a/packages/terraform/interface/VPC.ts
+++ b/packages/terraform/interface/VPC.ts
@@ -1,6 +1,5 @@
 export interface VPC {
     id: string;
-    name?: string;
     ipv4CidrBlock: string;
     defaultNetworkAclNo?: string;
     defaultAccessControlGroupNo?: string;

--- a/packages/terraform/main.ts
+++ b/packages/terraform/main.ts
@@ -4,21 +4,33 @@ import { saveTerraformFiles } from './util/file';
 async function main() {
     try {
         const converter = new TerraformConverter();
-        converter.addResourceFromJson({
-            id: 'server1',
-            type: 'Server',
-            name: 'my-server',
-            properties: {
-                server_image_number: 'rocky-8.10-base',
-                server_spec_code: 's2-g3',
-                subnet: 'my-subnet',
-                nic: 'my-nic',
-                loginKey: 'my-key',
-                vpc: 'my-vpc',
-                acg: 'my-acg',
-                region: 'KR',
+        converter.addResourceFromJson([
+            {
+                id: 'server1',
+                type: 'Server',
+                name: 'my-server',
+                properties: {
+                    server_image_number: 'rocky-8.10-base',
+                    server_spec_code: 's2-g3',
+                    subnet: 'my-subnet',
+                    vpc: 'my-vpc',
+                    region: 'KR',
+                },
             },
-        });
+
+            {
+                id: 'server',
+                type: 'Server',
+                name: 'my-server2',
+                properties: {
+                    server_image_number: 'rocky-8.10-base',
+                    server_spec_code: 's2-g3',
+                    subnet: 'my-subnet2',
+                    vpc: 'my-vpc2',
+                    region: 'KR',
+                },
+            },
+        ]);
         const terraformCode = converter.generate();
         await saveTerraformFiles(terraformCode, { log: true });
     } catch (error) {

--- a/packages/terraform/main.ts
+++ b/packages/terraform/main.ts
@@ -1,9 +1,9 @@
-import { TerraformConvertor } from './convertor/TerraformConvertor';
+import { TerraformConverter } from './converter/TerraformConverter';
 import { saveTerraformFiles } from './util/file';
 
 async function main() {
     try {
-        const converter = new TerraformConvertor();
+        const converter = new TerraformConverter();
         converter.addResourceFromJson({
             id: 'server1',
             type: 'Server',

--- a/packages/terraform/model/NCloudACG.ts
+++ b/packages/terraform/model/NCloudACG.ts
@@ -15,10 +15,10 @@ export class NCloudACG implements ACG, NCloudModel {
         this.priority = ResourcePriority.ACG;
         this.id = json.id || `ACG-${Date.now()}`;
         if (json.name) {
-            this.name = json.name;
+            this.name = json.name.toLowerCase();
         }
 
-        this.vpcNo = `ncloud_vpc.${json.vpcName}.id`;
+        this.vpcNo = `ncloud_vpc.${json.vpcName.toLowerCase()}.id`;
     }
 
     getProperties() {

--- a/packages/terraform/model/NCloudACGRule.ts
+++ b/packages/terraform/model/NCloudACGRule.ts
@@ -14,11 +14,11 @@ export class NCloudACGRule implements ACGRule, NCloudModel {
     constructor(json: any) {
         this.serviceType = 'ncloud_access_control_group_rule';
         this.priority = ResourcePriority.ACG_RULE;
-        this.name = json.name || 'acg-rule';
+        this.name = json.name.toLowerCase();
         this.protocol = json.protocol;
         this.ipBlock = json.ipBlock;
         this.portRange = json.portRange;
-        this.accessControlGroupNo = `ncloud_access_control_group.${json.acgName}.id`;
+        this.accessControlGroupNo = `ncloud_access_control_group.${json.acgName.toLowerCase()}.id`;
     }
 
     getProperties() {

--- a/packages/terraform/model/NCloudLaunchConfiguration.ts
+++ b/packages/terraform/model/NCloudLaunchConfiguration.ts
@@ -20,7 +20,7 @@ export class NCloudLaunchConfiguration
         this.serviceType = 'ncloud_launch_configuration';
         this.priority = ResourcePriority.LAUNCH_CONFIGURATION;
         this.id = json.id || `LaunchConfiguration-${Date.now()}`;
-        this.name = json.name || 'launch-config';
+        this.name = json.name.toLowerCase();
         this.serverImageProductCode =
             json.serverImageProductCode || 'SW.VSVR.OS.LNX64.CNTOS.0703.B050';
         this.serverProductCode =

--- a/packages/terraform/model/NCloudLoadBalancer.ts
+++ b/packages/terraform/model/NCloudLoadBalancer.ts
@@ -17,13 +17,19 @@ export class NCloudLoadBalancer implements LoadBalancer, NCloudModel {
     constructor(json: any) {
         this.serviceType = 'ncloud_lb';
         this.priority = ResourcePriority.LOAD_BALANCER;
-        this.id = json.id || `LoadBalancer-${Date.now()}`;
+        this.id = json.id;
         this.name = json.name.toLowerCase();
         this.networkType = json.networkType || 'PUBLIC';
         this.type = json.type || 'APPLICATION';
-        this.subnetNoList = [
-            `ncloud_subnet.${json.subnetName.toLowerCase()}.id`,
-        ];
+        if (Array.isArray(json.subnetName)) {
+            this.subnetNoList = json.subnetName.map(
+                (name: string) => `ncloud_subnet.${name.toLowerCase()}.id`,
+            );
+        } else {
+            this.subnetNoList = [
+                `ncloud_subnet.${json.subnetName.toLowerCase()}.id`,
+            ];
+        }
     }
 
     getProperties() {

--- a/packages/terraform/model/NCloudLoadBalancer.ts
+++ b/packages/terraform/model/NCloudLoadBalancer.ts
@@ -18,10 +18,12 @@ export class NCloudLoadBalancer implements LoadBalancer, NCloudModel {
         this.serviceType = 'ncloud_lb';
         this.priority = ResourcePriority.LOAD_BALANCER;
         this.id = json.id || `LoadBalancer-${Date.now()}`;
-        this.name = json.name || 'lb';
+        this.name = json.name.toLowerCase();
         this.networkType = json.networkType || 'PUBLIC';
         this.type = json.type || 'APPLICATION';
-        this.subnetNoList = [`ncloud_subnet.${json.subnetName}.id`];
+        this.subnetNoList = [
+            `ncloud_subnet.${json.subnetName.toLowerCase()}.id`,
+        ];
     }
 
     getProperties() {

--- a/packages/terraform/model/NCloudLoginKey.ts
+++ b/packages/terraform/model/NCloudLoginKey.ts
@@ -16,7 +16,7 @@ export class NCloudLoginKey implements LoginKey, NCloudModel {
         if (!json.name && !json.name) {
             throw new Error('key_name is required for Login Key');
         }
-        this.name = json.keyName || json.name;
+        this.name = json.name.toLowerCase();
     }
 
     getProperties() {

--- a/packages/terraform/model/NCloudMySQL.ts
+++ b/packages/terraform/model/NCloudMySQL.ts
@@ -52,11 +52,7 @@ export class NCloudMySQL implements MySQL, NCloudModel {
         if (!json.hostIp) {
             throw new Error('MySQL requires host_ip');
         }
-        if (
-            !json.databaseName ||
-            json.databaseName.length < 1 ||
-            json.databaseName.length > 30
-        ) {
+        if (!json.databaseName) {
             throw new Error('MySQL requires database_name (1-30 characters)');
         }
 
@@ -66,7 +62,7 @@ export class NCloudMySQL implements MySQL, NCloudModel {
         this.userPassword = json.userPassword;
         this.hostIp = json.hostIp;
         this.databaseName = json.databaseName;
-        this.subnetNo = 'SUBNET_ID_PLACEHOLDER';
+        this.subnetNo = `ncloud_subnet.${json.subnet.toLowerCase()}.id`;
     }
 
     getProperties() {

--- a/packages/terraform/model/NCloudMySQL.ts
+++ b/packages/terraform/model/NCloudMySQL.ts
@@ -60,7 +60,7 @@ export class NCloudMySQL implements MySQL, NCloudModel {
             throw new Error('MySQL requires database_name (1-30 characters)');
         }
 
-        this.serviceName = json.serviceName;
+        this.serviceName = json.serviceName.toLowerCase();
         this.serverNamePrefix = json.serverNamePrefix;
         this.userName = json.userName;
         this.userPassword = json.userPassword;

--- a/packages/terraform/model/NCloudNetworkACL.ts
+++ b/packages/terraform/model/NCloudNetworkACL.ts
@@ -13,8 +13,8 @@ export class NCloudNetworkACL implements NetworkACL, NCloudModel {
         this.serviceType = 'ncloud_network_acl';
         this.priority = ResourcePriority.NETWORK_ACL;
         this.id = json.id;
-        this.name = json.name || 'nacl';
-        this.vpcNo = `ncloud_vpc.${json.vpcName}.id`;
+        this.name = json.name.toLowerCase();
+        this.vpcNo = `ncloud_vpc.${json.vpcName.toLowerCase()}.id`;
     }
 
     getProperties() {

--- a/packages/terraform/model/NCloudNetworkInterface.ts
+++ b/packages/terraform/model/NCloudNetworkInterface.ts
@@ -14,10 +14,10 @@ export class NCloudNetworkInterface implements NetworkInterface, NCloudModel {
         this.serviceType = 'ncloud_network_interface';
         this.priority = ResourcePriority.NETWORK_INTERFACE;
         this.id = json.id || `nic-${Date.now()}`;
-        this.name = json.name || 'nic';
-        this.subnetNo = `ncloud_subnet.${json.subnetName}.id`;
+        this.name = json.name.toLowerCase();
+        this.subnetNo = `ncloud_subnet.${json.subnetName.toLowerCase()}.id`;
         this.accessControlGroups = [
-            `ncloud_access_control_group.${json.acgName}.id`,
+            `ncloud_access_control_group.${json.acgName.toLowerCase()}.id`,
         ];
     }
 

--- a/packages/terraform/model/NCloudObjectStorageBucket.ts
+++ b/packages/terraform/model/NCloudObjectStorageBucket.ts
@@ -1,0 +1,18 @@
+import { ObjectStorageBucket } from '../interface/ObjectStorageBucket';
+import { ResourcePriority } from '../enum/ResourcePriority';
+
+export class NCloudObjectStorageBucket implements ObjectStorageBucket {
+    bucketName: string;
+    serviceType: string;
+    priority: ResourcePriority;
+    constructor(json: any) {
+        this.serviceType = 'ncloud_objectstorage_bucket';
+        this.priority = ResourcePriority.OBJECT_STORAGE_BUCKET;
+        this.bucketName = json.bucketName;
+    }
+    getProperties() {
+        return {
+            bucket_name: this.bucketName,
+        };
+    }
+}

--- a/packages/terraform/model/NCloudProvider.ts
+++ b/packages/terraform/model/NCloudProvider.ts
@@ -16,7 +16,7 @@ export class NCloudProvider implements Provider {
         this.name = 'ncloud';
         this.accessKey = json.accessKey || 'var.access_key';
         this.secretKey = json.secretKey || 'var.secret_key';
-        this.region = json.region;
+        this.region = json.region.toUpperCase();
         this.site = json.site || 'public';
         this.requiredVersion = '>= 0.13';
         this.source = 'NaverCloudPlatform/ncloud';

--- a/packages/terraform/model/NCloudPublicIP.ts
+++ b/packages/terraform/model/NCloudPublicIP.ts
@@ -15,7 +15,7 @@ export class NCloudPublicIP implements PublicIp, NCloudModel {
         this.serviceType = 'ncloud_public_ip';
         this.priority = ResourcePriority.PUBLIC_IP;
         this.id = json.id || `publicIp-${Date.now()}`;
-        this.name = json.name;
+        this.name = json.name.toLowerCase();
         this.serverInstanceNo = `ncloud_server.${json.serverName}.id`;
     }
 

--- a/packages/terraform/model/NCloudRedis.ts
+++ b/packages/terraform/model/NCloudRedis.ts
@@ -1,0 +1,34 @@
+import { Redis } from '../interface/Redis';
+import { NCloudModel } from '../interface/NCloudModel';
+import { ResourcePriority } from '../enum/ResourcePriority';
+
+export class NCloudRedis implements Redis, NCloudModel {
+    serviceType: string;
+    serviceName: string;
+    serverNamePrefix: string;
+    vpcNo: string;
+    subnetNo: string;
+    configGroupNo: string;
+    mode: string;
+    priority: ResourcePriority;
+    constructor(json: any) {
+        this.serviceType = 'ncloud_redis';
+        this.serviceName = json.serviceName;
+        this.serverNamePrefix = json.serverNamePrefix;
+        this.vpcNo = `ncloud_vpc.${json.vpcNo.toLowerCase()}.id`;
+        this.subnetNo = `ncloud_subnet.${json.subnetNo.toLowerCase()}.id`;
+        this.configGroupNo = `ncloud_redis_config_group.${json.configGroupNo.toLowerCase()}.id`;
+        this.mode = json.mode;
+        this.priority = ResourcePriority.REDIS;
+    }
+    getProperties() {
+        return {
+            service_name: this.serviceName,
+            service_name_prefix: this.serverNamePrefix,
+            vpc_no: this.vpcNo,
+            subnet_no: this.subnetNo,
+            config_group_no: this.configGroupNo,
+            mode: this.mode,
+        };
+    }
+}

--- a/packages/terraform/model/NCloudRedisConfigGroup.ts
+++ b/packages/terraform/model/NCloudRedisConfigGroup.ts
@@ -1,0 +1,25 @@
+import { RedisConfigGroup } from '../interface/RedisConfigGroup';
+import { NCloudModel } from '../interface/NCloudModel';
+import { ResourcePriority } from '../enum/ResourcePriority';
+
+export class NCloudRedisConfigGroup implements RedisConfigGroup, NCloudModel {
+    name: string;
+    serviceType: string;
+    redisVersion: string;
+    description?: string;
+    priority: ResourcePriority;
+    constructor(json: any) {
+        this.serviceType = 'ncloud_redis_config_group';
+        this.name = json.name;
+        this.priority = ResourcePriority.REDIS_CONFIG_GROUP;
+        this.redisVersion = json.redisVersion;
+        this.description = json.description;
+    }
+    getProperties() {
+        return {
+            name: this.name,
+            redis_version: this.redisVersion,
+            description: this.description,
+        };
+    }
+}

--- a/packages/terraform/model/NCloudServer.ts
+++ b/packages/terraform/model/NCloudServer.ts
@@ -18,18 +18,18 @@ export class NCloudServer implements Server, NCloudModel {
         this.serviceType = 'ncloud_server';
         this.priority = ResourcePriority.SERVER;
         this.id = json.id;
-        this.name = json.name;
-        this.subnetNo = `ncloud_subnet.${json.subnetName}.id`;
+        this.name = json.name.toLowerCase();
+        this.subnetNo = `ncloud_subnet.${json.subnetName.toLowerCase()}.id`;
         this.serverImageNumber = json.serverImageNumber;
         this.serverSpecCode = json.serverSpecCode;
         if (json.loginKeyName) {
-            this.loginKeyName = `ncloud_login_key.${json.loginKeyName}.key_name`;
+            this.loginKeyName = `ncloud_login_key.${json.loginKeyName.toLowerCase()}.key_name`;
         }
         if (json.nicName) {
-            this.networkInterfaceNo = `ncloud_network_interface.${json.nicName}.id`;
+            this.networkInterfaceNo = `ncloud_network_interface.${json.nicName.toLowerCase()}.id`;
         }
         if (json.acgName) {
-            this.acgName = `ncloud_acg.${json.acgName}.id`;
+            this.acgName = `ncloud_acg.${json.acgName.toLowerCase()}.id`;
         }
     }
 

--- a/packages/terraform/model/NCloudSubnet.ts
+++ b/packages/terraform/model/NCloudSubnet.ts
@@ -36,7 +36,7 @@ export class NCloudSubnet implements Subnet, NCloudModel {
         this.subnetType = json.subnetType;
 
         if (json.name) {
-            this.name = json.name;
+            this.name = json.name.toLowerCase();
         }
 
         if (
@@ -48,8 +48,8 @@ export class NCloudSubnet implements Subnet, NCloudModel {
             this.usageType = 'GEN';
         }
 
-        this.vpcNo = `ncloud_vpc.${json.vpcName}.id`;
-        this.networkAclNo = `ncloud_vpc.${json.vpcName}.default_network_acl_no`;
+        this.vpcNo = `ncloud_vpc.${json.vpcName.toLowerCase()}.id`;
+        this.networkAclNo = `ncloud_vpc.${json.vpcName.toLowerCase()}.default_network_acl_no`;
     }
 
     getProperties() {

--- a/packages/terraform/model/NCloudVPC.ts
+++ b/packages/terraform/model/NCloudVPC.ts
@@ -18,7 +18,7 @@ export class NCloudVPC implements VPC, NCloudModel {
         this.priority = ResourcePriority.VPC;
         this.id = json.id;
         if (json.name) {
-            this.name = json.name;
+            this.name = json.name.toLowerCase();
         }
         if (!json.ipv4CidrBlock) {
             throw new Error('ipv4CidrBlock is required for VPC');

--- a/packages/terraform/test/TerraformConverter.spec.ts
+++ b/packages/terraform/test/TerraformConverter.spec.ts
@@ -1,18 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { NCloudProvider } from '../model/NCloudProvider';
-import { TerraformConvertor } from '../convertor/TerraformConvertor';
+import { TerraformConverter } from '../converter/TerraformConverter';
 
 describe('TerraformConvertor', () => {
-    const provider = new NCloudProvider({
-        accessKey: 'var.access_key',
-        secretKey: 'var.secret_key',
-        region: 'var.region',
-        site: 'public',
-    });
-
     it('유효한 Terraform 코드를 생성해야 함', () => {
-        const converter = new TerraformConvertor(provider);
-        const code = converter.generate();
+        const converter = new TerraformConverter();
+        const code = converter.generate;
 
         expect(code).toContain('terraform {');
         expect(code).toContain('provider "ncloud"');
@@ -20,7 +12,7 @@ describe('TerraformConvertor', () => {
     });
 
     it('리소스를 올바르게 생성해야 함', () => {
-        const converter = new TerraformConvertor(provider);
+        const converter = new TerraformConverter();
         converter.addResourceFromJson({
             nodes: [
                 {

--- a/packages/terraform/util/dependency.ts
+++ b/packages/terraform/util/dependency.ts
@@ -13,20 +13,42 @@ export const createVpcDependency = (properties: any): CloudCanvasNode => ({
 export const createSubnetDependency = (
     properties: any,
     resourceType: string,
-): CloudCanvasNode => ({
-    id: `subnet-${properties.subnet}`,
-    type: 'Subnet',
-    name: properties.subnet,
-    properties: {
-        subnet: properties.subnetCidr || '172.16.10.0/24',
-        zone: properties.zone || getZoneByRegion(properties.region),
-        subnetType: properties.subnetType || 'PUBLIC',
-        usageType:
-            properties.usageType || getUsageTypeByResourceType(resourceType),
-        vpcName: properties.vpc,
-        region: properties.region,
-    },
-});
+): CloudCanvasNode[] => {
+    if (Array.isArray(properties.subnet)) {
+        return properties.subnet.map((subnetName: any) => ({
+            id: `subnet-${subnetName}`,
+            type: 'Subnet',
+            name: subnetName,
+            properties: {
+                subnet: properties.subnetCidr || '172.16.10.0/24',
+                zone: properties.zone || getZoneByRegion(properties.region),
+                subnetType: properties.subnetType || 'PUBLIC',
+                usageType:
+                    properties.usageType ||
+                    getUsageTypeByResourceType(resourceType),
+                vpcName: properties.vpc,
+                region: properties.region,
+            },
+        }));
+    }
+    return [
+        {
+            id: `subnet-${properties.subnet}`,
+            type: 'Subnet',
+            name: properties.subnet,
+            properties: {
+                subnet: properties.subnetCidr || '172.16.10.0/24',
+                zone: properties.zone || getZoneByRegion(properties.region),
+                subnetType: properties.subnetType || 'PUBLIC',
+                usageType:
+                    properties.usageType ||
+                    getUsageTypeByResourceType(resourceType),
+                vpcName: properties.vpc,
+                region: properties.region,
+            },
+        },
+    ];
+};
 
 export const createAcgDependencies = (
     properties: any,
@@ -73,6 +95,16 @@ export const createLoginKeyDependency = (properties: any): CloudCanvasNode => ({
     type: 'LoginKey',
     name: properties.loginKey,
     properties: {
+        region: properties.region,
+    },
+});
+
+export const createRedisConfigGroup = (properties: any): CloudCanvasNode => ({
+    id: `redisconfig-${properties.configGroup}`,
+    type: 'RedisConfigGroup',
+    name: properties.configGroup,
+    properties: {
+        redisVersion: properties.redisVersion,
         region: properties.region,
     },
 });

--- a/packages/terraform/util/resource.ts
+++ b/packages/terraform/util/resource.ts
@@ -5,10 +5,15 @@ import {
     createNicDependency,
     createSubnetDependency,
     createVpcDependency,
+    createRedisConfigGroup,
 } from './dependency';
 
 export const processDependencies = (node: any): any[] => {
-    if (!['server', 'loadbalancer', 'mysql'].includes(node.type.toLowerCase()))
+    if (
+        !['server', 'loadbalancer', 'mysql', 'redis'].includes(
+            node.type.toLowerCase(),
+        )
+    )
         return [];
 
     const dependencies: CloudCanvasNode[] = [];
@@ -17,12 +22,14 @@ export const processDependencies = (node: any): any[] => {
         dependencies.push(createVpcDependency(properties));
     }
     if (properties.subnet) {
-        dependencies.push(createSubnetDependency(properties, node.type));
+        dependencies.push(...createSubnetDependency(properties, node.type));
     }
     if (properties.acg) {
         dependencies.push(...createAcgDependencies(properties, node.name));
     }
-
+    if (properties.configGroup) {
+        dependencies.push(createRedisConfigGroup(properties));
+    }
     // if (node.type.toLowerCase() === 'server') {
     //     // if (properties.nic) {
     //     //     dependencies.push(createNicDependency(properties));

--- a/packages/terraform/util/resourceParser.ts
+++ b/packages/terraform/util/resourceParser.ts
@@ -122,6 +122,8 @@ export function parseToNCloudModel(resource: any): NCloudModel {
                 userPassword: properties.userPassword,
                 hostIp: properties.hostIp,
                 databaseName: properties.databaseName,
+                subnet: properties.subnet,
+                vpc: properties.vpc,
             });
         default:
             throw new Error(`Unsupported resource type: ${type}`);

--- a/packages/terraform/util/resourceParser.ts
+++ b/packages/terraform/util/resourceParser.ts
@@ -11,6 +11,8 @@ import { NCloudPublicIP } from '../model/NCloudPublicIP';
 import { NCloudLoadBalancer } from '../model/NCloudLoadBalancer';
 import { NCloudLaunchConfiguration } from '../model/NCloudLaunchConfiguration';
 import { NCloudMySQL } from '../model/NCloudMySQL';
+import { NCloudObjectStorageBucket } from '../model/NCloudObjectStorageBucket';
+import { NCloudRedis } from '../model/NCloudRedis';
 
 export function parseToNCloudModel(resource: any): NCloudModel {
     const { type, name, properties } = resource;
@@ -29,7 +31,6 @@ export function parseToNCloudModel(resource: any): NCloudModel {
             });
 
         case 'subnet':
-            console.log('subnet properties', properties);
             return new NCloudSubnet({
                 name: name || 'subnet',
                 subnet: properties.subnet,
@@ -88,12 +89,11 @@ export function parseToNCloudModel(resource: any): NCloudModel {
 
         case 'loadbalancer':
             return new NCloudLoadBalancer({
-                name: name || 'lb',
+                name: name || 'load-balancer',
                 networkType: properties.networkType,
-                throughputType: properties.throughputType,
+                type: properties.type,
                 subnetName: properties.subnet,
-                vpcName: properties.vpcName,
-                acgName: properties.acgName,
+                vpcName: properties.vpc,
             });
 
         case 'launchconfiguration':
@@ -124,6 +124,21 @@ export function parseToNCloudModel(resource: any): NCloudModel {
                 databaseName: properties.databaseName,
                 subnet: properties.subnet,
                 vpc: properties.vpc,
+            });
+
+        case 'objectstoragebucket':
+            return new NCloudObjectStorageBucket({
+                bucketName: properties.bucketName,
+            });
+
+        case 'redis':
+            return new NCloudRedis({
+                serviceName: name || 'redis',
+                serverNamePrefix: properties.serverNamePrefix,
+                vpcNo: properties.vpc,
+                subnetNo: properties.subnet,
+                configGroupNo: properties.configGroup,
+                mode: properties.mode,
             });
         default:
             throw new Error(`Unsupported resource type: ${type}`);

--- a/packages/terraform/util/resourceParser.ts
+++ b/packages/terraform/util/resourceParser.ts
@@ -1,4 +1,3 @@
-import { CloudCanvasNode } from '../interface/CloudCanvasNode';
 import { NCloudModel } from '../interface/NCloudModel';
 import { NCloudVPC } from '../model/NCloudVPC';
 import { NCloudNetworkACL } from '../model/NCloudNetworkACL';


### PR DESCRIPTION
## 연관 이슈
#155 
#154 

## 주요 작업
## 1. 리소스 참조 문제

### 초기 상황

```tsx
// 초기 구현 - placeholder 사용
getProperties() {
    return {
        vpc_no: 'VPC_ID_PLACEHOLDER',
        subnet_no: 'SUBNET_ID_PLACEHOLDER'
    };
}

```

### 발생한 문제

1. 생성된 테라폼 코드에서 참조가 문자열로 처리됨

```hcl
resource "ncloud_subnet" "my-subnet" {
    vpc_no = "ncloud_vpc.my-vpc.id"// 잘못된 참조 (문자열)
}

```

### 해결 과정

1. reference 처리 로직 분리

```tsx
export const isNcloudReference = (value: string): boolean => {
    const ncloudRefPattern = /^ncloud_[a-zA-Z_]+\.[a-zA-Z_-]+\.(id|default_network_acl_no)$/;
    return ncloudRefPattern.test(value);
};

export const formatValue = (value: any): string => {
    if (typeof value === 'string' && isNcloudReference(value)) {
        return value;// 참조는 따옴표 없이 반환
    }
    return `"${value}"`;
};

```

1. 리소스 참조 생성 방식 변경

```tsx
constructor(json: any) {
    this.subnetNo = `ncloud_subnet.${json.subnetName}.id`;// 직접 참조 형식 사용
}

```

## 2. 리소스 의존성 순환 참조 문제

### 초기 상황

- VPC → NetworkACL → Subnet → Server 순으로 의존성 존재
- 순환 참조 발생 가능성

### 해결 과정

1. ResourcePriority 열거형 도입

```tsx
export enum ResourcePriority {
    VPC = 1,
    NETWORK_ACL = 2,
    SUBNET = 3,
    ACG = 4,
// ...
}

```

1. 리소스 정렬 로직 구현

```tsx
getResources(): NCloudModel[] {
    return [...this.resources].sort((a, b) => a.priority - b.priority);
}

```

## 3. 다중 리전 처리 문제

### 초기 상황

- 모든 리소스가 동일한 리전에 생성된다고 가정
- 리전별 provider 설정 누락

### 발생한 문제

```hcl
// 잘못된 코드 생성
resource "ncloud_vpc" "vpc-1" {
// region 정보 누락
}

```

### 해결 과정

1. Provider 관리 로직 추가

```tsx
private providers: Map<string, NCloudProvider>;

addResourceFromJson(jsonData: { nodes?: CloudCanvasNode[] }): void {
    const regions = this.collectRegions(jsonData.nodes || []);
    regions.forEach(region => {
        const provider = new NCloudProvider({
            region: region,
            alias: region.toLowerCase()
        });
        this.providers.set(region, provider);
    });
}

```

1. 리소스별 provider 참조 추가

```tsx
getProperties() {
    return {
        ...properties,
        provider: `ncloud.${this.region.toLowerCase()}`
    };
}

```

## 구현 결과

```     
{
         id: 'loadbalancer',
         type: 'loadbalancer',
         name: 'myloadbalancer',
         properties: {
             networkType: 'PUBLIC',
             type: 'APPLICATION',
             subnet: ['my-subnet', 'test'],
             vpc: 'my-vpc',
             region: 'KR',
         },
},
{
         id: 'objectstoragebucket',
         type: 'objectstoragebucket',
         properties: {
             bucketName: 'my-bucket',
             region: 'KR',
         },
},
{
         type: 'redis',
         name: 'my-redis',
         properties: {
             serviceName: 'my-tf-redis',
             serverNamePrefix: 'tf-svr',
             vpc: 'example-v',
             subnet: 'example-sub',
             configGroup: 'example-rcg',
             mode: 'SIMPLE',
         },
},

{
         id: 'mysql',
         type: 'mysql',
         name: 'my-mysql',
         properties: {
             serviceName: 'mysql',
             serverNamePrefix: 'name-prefix',
             userName: 'dongmin',
             userPassword: 'test1234!',
             hostIp: '192.168.0.1',
             databaseName: 'my-database',
             subnet: 'my-subnet',
             vpc: 'my-vpc',
             region: 'KR',
         },
},
```


